### PR TITLE
Spring Application Advisor: Upgrade Java 8 to 11

### DIFF
--- a/.advisor/errors/20250612-160907235.log
+++ b/.advisor/errors/20250612-160907235.log
@@ -1,0 +1,6411 @@
+Spring Application Advisor CLI Version: 1.3.1
+java.lang.IllegalArgumentException: URI with undefined scheme
+	at java.net.http@23.0.2/jdk.internal.net.http.common.Utils.newIAE(Utils.java:378)
+	at java.net.http@23.0.2/jdk.internal.net.http.HttpRequestBuilderImpl.checkURI(HttpRequestBuilderImpl.java:79)
+	at java.net.http@23.0.2/jdk.internal.net.http.HttpRequestBuilderImpl.uri(HttpRequestBuilderImpl.java:71)
+	at java.net.http@23.0.2/jdk.internal.net.http.HttpRequestBuilderImpl.uri(HttpRequestBuilderImpl.java:43)
+	at org.springframework.http.client.JdkClientHttpRequest.buildRequest(JdkClientHttpRequest.java:142)
+	at org.springframework.http.client.JdkClientHttpRequest.executeInternal(JdkClientHttpRequest.java:101)
+	at org.springframework.http.client.AbstractStreamingClientHttpRequest.executeInternal(AbstractStreamingClientHttpRequest.java:71)
+	at org.springframework.http.client.AbstractClientHttpRequest.execute(AbstractClientHttpRequest.java:81)
+	at org.springframework.http.client.InterceptingClientHttpRequest$InterceptingRequestExecution.execute(InterceptingClientHttpRequest.java:117)
+	at com.vmware.tanzu.spring.advisor.cli.platform.GZipInterceptor.intercept(GZipInterceptor.java:24)
+	at org.springframework.http.client.InterceptingClientHttpRequest$InterceptingRequestExecution.execute(InterceptingClientHttpRequest.java:88)
+	at org.springframework.http.client.InterceptingClientHttpRequest.executeInternal(InterceptingClientHttpRequest.java:72)
+	at org.springframework.http.client.AbstractBufferingClientHttpRequest.executeInternal(AbstractBufferingClientHttpRequest.java:48)
+	at org.springframework.http.client.AbstractClientHttpRequest.execute(AbstractClientHttpRequest.java:81)
+	at org.springframework.web.client.DefaultRestClient$DefaultRequestBodyUriSpec.exchangeInternal(DefaultRestClient.java:576)
+	at org.springframework.web.client.DefaultRestClient$DefaultRequestBodyUriSpec.exchange(DefaultRestClient.java:533)
+	at org.springframework.web.client.RestClient$RequestHeadersSpec.exchange(RestClient.java:680)
+	at org.springframework.web.client.DefaultRestClient$DefaultResponseSpec.executeAndExtract(DefaultRestClient.java:814)
+	at org.springframework.web.client.DefaultRestClient$DefaultResponseSpec.toEntityInternal(DefaultRestClient.java:774)
+	at org.springframework.web.client.DefaultRestClient$DefaultResponseSpec.toEntity(DefaultRestClient.java:763)
+	at com.vmware.tanzu.spring.advisor.cli.platform.TanzuPlatformPublishService.publish(TanzuPlatformPublishService.java:70)
+	at com.vmware.tanzu.spring.advisor.cli.buildconfig.BuildConfigurationPublishCommand.runCommand(BuildConfigurationPublishCommand.java:82)
+	at com.vmware.tanzu.spring.advisor.cli.Command.run(Command.java:12)
+	at picocli.CommandLine.executeUserObject(CommandLine.java:2045)
+	at picocli.CommandLine.access$1500(CommandLine.java:148)
+	at picocli.CommandLine$RunLast.executeUserObjectOfLastSubcommandWithSameParent(CommandLine.java:2469)
+	at picocli.CommandLine$RunLast.handle(CommandLine.java:2461)
+	at picocli.CommandLine$RunLast.handle(CommandLine.java:2423)
+	at picocli.CommandLine$AbstractParseResultHandler.execute(CommandLine.java:2277)
+	at picocli.CommandLine$RunLast.execute(CommandLine.java:2425)
+	at picocli.CommandLine.execute(CommandLine.java:2174)
+	at com.vmware.tanzu.spring.advisor.cli.CommandLineApplicationRunner.run(CommandLineApplicationRunner.java:27)
+	at org.springframework.boot.SpringApplication.lambda$callRunner$5(SpringApplication.java:789)
+	at org.springframework.util.function.ThrowingConsumer$1.acceptWithException(ThrowingConsumer.java:82)
+	at org.springframework.util.function.ThrowingConsumer.accept(ThrowingConsumer.java:60)
+	at org.springframework.util.function.ThrowingConsumer$1.accept(ThrowingConsumer.java:86)
+	at org.springframework.boot.SpringApplication.callRunner(SpringApplication.java:797)
+	at org.springframework.boot.SpringApplication.callRunner(SpringApplication.java:788)
+	at org.springframework.boot.SpringApplication.lambda$callRunners$3(SpringApplication.java:773)
+	at java.base@23.0.2/java.util.stream.ForEachOps$ForEachOp$OfRef.accept(ForEachOps.java:184)
+	at java.base@23.0.2/java.util.stream.SortedOps$SizedRefSortingSink.end(SortedOps.java:357)
+	at java.base@23.0.2/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:571)
+	at java.base@23.0.2/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:560)
+	at java.base@23.0.2/java.util.stream.ForEachOps$ForEachOp.evaluateSequential(ForEachOps.java:151)
+	at java.base@23.0.2/java.util.stream.ForEachOps$ForEachOp$OfRef.evaluateSequential(ForEachOps.java:174)
+	at java.base@23.0.2/java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:265)
+	at java.base@23.0.2/java.util.stream.ReferencePipeline.forEach(ReferencePipeline.java:636)
+	at org.springframework.boot.SpringApplication.callRunners(SpringApplication.java:773)
+	at org.springframework.boot.SpringApplication.run(SpringApplication.java:325)
+	at org.springframework.boot.SpringApplication.run(SpringApplication.java:1362)
+	at org.springframework.boot.SpringApplication.run(SpringApplication.java:1351)
+	at com.vmware.tanzu.spring.advisor.cli.CommandLineApplication.main(CommandLineApplication.java:15)
+	at java.base@23.0.2/java.lang.invoke.LambdaForm$DMH/sa346b79c.invokeStaticInit(LambdaForm$DMH)
+
+
+^========= [ build-config.json ] =========
+{
+  "sbom": {
+  "bomFormat" : "CycloneDX",
+  "specVersion" : "1.5",
+  "serialNumber" : "urn:uuid:7061251d-47b7-3ac0-930e-968cbc34f7be",
+  "version" : 1,
+  "metadata" : {
+    "timestamp" : "2025-06-12T16:08:08Z",
+    "lifecycles" : [
+      {
+        "phase" : "build"
+      }
+    ],
+    "tools" : [
+      {
+        "vendor" : "OWASP Foundation",
+        "name" : "CycloneDX Maven plugin",
+        "version" : "2.8.0",
+        "hashes" : [
+          {
+            "alg" : "MD5",
+            "content" : "76ffec6a7ddd46b2b24517411874eb99"
+          },
+          {
+            "alg" : "SHA-1",
+            "content" : "5b0d5b41975b53be4799b9621b4af0cfc41d44b6"
+          },
+          {
+            "alg" : "SHA-256",
+            "content" : "6852aa0f4e42a2db745bab80e384951a6a65b9215d041081d675780999027e81"
+          },
+          {
+            "alg" : "SHA-512",
+            "content" : "417de20fcdcb11c9713bacbd57290d8e68037fdb4553fd31b8cb08bd760ad52dc65ea88ad4be15844ad3fd5a4d3e440d2f70326f2fe1e63ec78e059c9a883f8d"
+          },
+          {
+            "alg" : "SHA-384",
+            "content" : "5eb755c6492e7a7385fa9a1e1f4517875bcb834b2df437808a37a2d6f5285df428741762305980315a63fcef1406597d"
+          },
+          {
+            "alg" : "SHA3-384",
+            "content" : "0fe16a47cf7aab0b22251dafcc39939b68e8f1778093309d8d2060b51a08df445a8b8ed5a9561669faf2e55f907c76d8"
+          },
+          {
+            "alg" : "SHA3-256",
+            "content" : "3e5a1eb5ab7d0797498862794709ff8eaaa071fe4cc9ec77f52db7e2f97ef487"
+          },
+          {
+            "alg" : "SHA3-512",
+            "content" : "59281a3e29e76270d7f44b40b5b9f05e55f1ae3ec716d80add806f360940809e3813998ac7c5758043b8e248aed73b86e37dc506cdb4cde03c16bb617d8e5a3a"
+          }
+        ]
+      }
+    ],
+    "component" : {
+      "group" : "org.springframework.samples",
+      "name" : "spring-petclinic",
+      "version" : "2.7.3",
+      "description" : "Parent pom providing dependency and plugin management for applications built with Maven",
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.springframework.samples/spring-petclinic@2.7.3?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://spring.io/projects/spring-boot/spring-petclinic"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/spring-projects/spring-boot/spring-petclinic"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.springframework.samples/spring-petclinic@2.7.3?type=jar"
+    },
+    "properties" : [
+      {
+        "name" : "maven.goal",
+        "value" : "makeAggregateBom"
+      },
+      {
+        "name" : "maven.scopes",
+        "value" : "compile,provided,runtime,system"
+      }
+    ]
+  },
+  "components" : [
+    {
+      "publisher" : "Pivotal Software, Inc.",
+      "group" : "org.springframework.boot",
+      "name" : "spring-boot-starter-actuator",
+      "version" : "2.7.3",
+      "description" : "Starter for using Spring Boot's Actuator which provides production ready features to help you monitor and manage your application",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "af3f145e2a3f130abf684c3b30d82398"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "dfc9122bab9213d6bbed1b77921ceffc0b16538f"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "ea6155624148ae58bde38e72dd14c1b8915d5c204a833ed52f5c42617a14ba5b"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "a6d1867927c91a6a88bb3432830394ad41a4f0d515d00288f715844384b1a15ecedc5495500e32e0af94a75619adbc9e9a54030792d8fe0b23990d4d721b0546"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "3c3e09ea6ba2185d1743368a53d826f3c44fd7536a8a1af3ce506a2b6fc5f3fe81c0e1281dcd9468b517c6956632a1f6"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "4e2d502ecda728e318eca54c9851c04cf64dfb0d4fb74cfd590cb11d3c7b66b2bd011e54a15526968ce8b031c8cc5115"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "65d19cf18e3d6b24971a6d295dc2dad8d3f534b70c9f318dd3228b404b6816e8"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "cfea78d22be22219b44fd8d5daaa3afb274390a183b3db6c45af4f0c8f2ee22b8616d2a48a30a0e3aafa911c86a164271f4a557a606ef5a1d1a3bea9509bdbe0"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.springframework.boot/spring-boot-starter-actuator@2.7.3?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://spring.io/projects/spring-boot"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/spring-projects/spring-boot/issues"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/spring-projects/spring-boot"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.springframework.boot/spring-boot-starter-actuator@2.7.3?type=jar"
+    },
+    {
+      "publisher" : "Pivotal Software, Inc.",
+      "group" : "org.springframework.boot",
+      "name" : "spring-boot-starter",
+      "version" : "2.7.3",
+      "description" : "Core starter, including auto-configuration support, logging and YAML",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "4108a60fa81b19d10599a42a733cceba"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "6b0c093af667bf645cd5f49372e2a2540ae2855f"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "3df6c34b9f02210a75277ee3fe2e397ecc100947cca7883f4c2856f5d47ed204"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "874e4fad0ce0a6a08365e3c2b65f774c2856959e599206e3c912edd0acb1edc5dbf6d8b6d5b32b91b282d0e16b8374ad39ed541b17a81cf403231ea958acb579"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "1589abc84b274408b90e45a20de614351eb6df2fd77426503453fd1a0ce0c9c5c90cef46bc5a8d8b3154556d73c179d3"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "f35099243c2e55a603cfd9b9e64489f7d135b51cea15fc456903cae6a9590434ab1af4782aaa5308b4c4ef294da153d3"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "d58c981424936c3a779c5bcec0fe77244354f8285746fc4a610c66072fd2379d"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "b3133f5a3080e766aacc1de0c126b122239cc8a0e06ff4c8071420e1ef94910cf7e7fb5887d1f20710e3d1594d4ce251fb325fac92f5b804f5fe3adff5d07f9f"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.springframework.boot/spring-boot-starter@2.7.3?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://spring.io/projects/spring-boot"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/spring-projects/spring-boot/issues"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/spring-projects/spring-boot"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.springframework.boot/spring-boot-starter@2.7.3?type=jar"
+    },
+    {
+      "publisher" : "Pivotal Software, Inc.",
+      "group" : "org.springframework.boot",
+      "name" : "spring-boot-starter-logging",
+      "version" : "2.7.3",
+      "description" : "Starter for logging using Logback. Default logging starter",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "87a80137cd878d906d2d4918b2e5f09b"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "a1e4a13b656182ba10b4c0c7848f91cd6f854fdf"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "ca0953f65d5b36a85b5652fb4a3a0c5bad78553932838fb097bbe4641521f2f2"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "eea041098bc7dbbb63ea0705d068cb01bbbcfa803adb787cc93d9fcbd621fc8530cdc26cbaec92b4abc57fae91b6a9b6cd6c13e4bf260f2104c5323a51eeee77"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "4f0d4e3aca18e45eb90d6c2656aad859835a03856f81cc211c35f9403da7df37ef86891b6ea7ec6987ae3b44ebc15852"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "def9c19d7520961a7ffe2b142d4ac1d978ed36617b8e6b86343123a546d93ac1d053dbc48055a697129ec33b4d83d3fc"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "fdd29b2477737d27577363bd7ef6e19b7bb5ceb7087d2d20e74f7ea1a342a1dd"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "8d562a9f022f34d3d2bcc943acc2a7070c05d0007aca2bc74ac5847db610d4632904e6bbfba2923eebe17a05c1df7f813392e5d082cecbd80a5351f1b0af87e9"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.springframework.boot/spring-boot-starter-logging@2.7.3?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://spring.io/projects/spring-boot"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/spring-projects/spring-boot/issues"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/spring-projects/spring-boot"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.springframework.boot/spring-boot-starter-logging@2.7.3?type=jar"
+    },
+    {
+      "publisher" : "QOS.ch",
+      "group" : "ch.qos.logback",
+      "name" : "logback-classic",
+      "version" : "1.2.11",
+      "description" : "logback-classic module",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "e13679004cc76ad5792f275f04884fab"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "4741689214e9d1e8408b206506cbe76d1c6a7d60"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "4d8e899621a3006c2f66e19feab002b11e6cfc5cb1854fc41f01532c00deb2aa"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "6df8b42396c5d3257f11fb19c280533aa28d66e647115816d4ebfd6a58c9b5adf0e098504772261b29435df75b86cb2b9a47f846ed45d770179c9d10f39941de"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "d480881d1a0d58c94aba0b719d56cd492147bc6481b67370dc7426ea7a81326af5b19f32d6a95fee714f37b90a5eed76"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "070647c93da744f04cc13ab3f1958c61a8b1e219fe221ed0bf251e4cc97563c64be323bfb3a9e2fd4839e33ded424b21"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "60c1dbe51066ffb3885673255a279e8894c89fe26f079180fa992478c1d9b03e"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "ce16fae69767bca975bec0d7dd0ceeb40c15cf034a4a949721c828a0f2c25cb9d619c4db3f986f6d9805d5b76d27b8926c55be5579522cd5ab3fa5e69bb68aeb"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "EPL-1.0"
+          }
+        },
+        {
+          "license" : {
+            "name" : "GNU Lesser General Public License",
+            "url" : "http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/ch.qos.logback/logback-classic@1.2.11?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "http://logback.qos.ch/logback-classic"
+        },
+        {
+          "type" : "distribution-intake",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/ceki/logback/logback-classic"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/ch.qos.logback/logback-classic@1.2.11?type=jar"
+    },
+    {
+      "publisher" : "QOS.ch",
+      "group" : "ch.qos.logback",
+      "name" : "logback-core",
+      "version" : "1.2.11",
+      "description" : "logback-core module",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "115da115b5e66ef64e774ec35af1fb1a"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "a01230df5ca5c34540cdaa3ad5efb012f1f1f792"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "6ce1e9397be8298a2e99029f55f955c6fa3cef255171c554d0b9c201cffd0159"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "86b12a74c2a822a12ba2e9a7b0db5013803f18784a3cb1201c95d5f7872a6aa8cf06d5861a5c35777a7decc7ea26df7b4388fab3b3b71aab7274527d9b339318"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "2afd896ebe6333d99e5baa553d80b7851d8ff51c06c725267e061df81bc9a878b74a65394699ae853f9738a08963aa0a"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "43d39acc5608b60d671c000bf6114f4623d3057399142abca01b0fc2381f2191479a2f0dd74f812223b66f57fa48fd9c"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "c23af1733b972e958369a2e14372fd2b306d4f552d7ae5ff6b9dfad3c14611c6"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "c7f6357d32a3b9fd82dfbd162c3a6cbe4b4909ef530e956bcd18649b2d3624eb51c5a71fee54533a9786e87cf1ccdc693f563ef6e3c6fbff7beedbd1d670f9bb"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "EPL-1.0"
+          }
+        },
+        {
+          "license" : {
+            "name" : "GNU Lesser General Public License",
+            "url" : "http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/ch.qos.logback/logback-core@1.2.11?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "http://logback.qos.ch/logback-core"
+        },
+        {
+          "type" : "distribution-intake",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/ceki/logback/logback-core"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/ch.qos.logback/logback-core@1.2.11?type=jar"
+    },
+    {
+      "publisher" : "The Apache Software Foundation",
+      "group" : "org.apache.logging.log4j",
+      "name" : "log4j-to-slf4j",
+      "version" : "2.17.2",
+      "description" : "The Apache Log4j binding between Log4j 2 API and SLF4J.",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "14b27a4266c6d71c949cb4591ee463cc"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "17dd0fae2747d9a28c67bc9534108823d2376b46"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "9bcfa5273527b950d79739d11e8f8080cfc881908fa2a946b4e891c0293094de"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "c90bbaacaabeed35f80be4d723b54234fd137413888870d6e1c1b16c067cbede57d637a18f0d25421a9c419fc55a9c388ce235077cfd6497178dfe67c5d398e8"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "c8374c05542d5a04a831a66596fe31cf385a303643e724840a70508aaa98e4870234aa8a26ac1f4fab167fe45bf34e6f"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "25c843c30137e459b94476843d8312a49d75b40d80469b1943b44a6bd2fd51f6b6f71b23d4bc559f91ae0f28763c7b0b"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "d0e8a8996e79cc881a10a55b4887436a9458625007f03b071230d1c4e96b54b6"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "6d0ec7c51ea40dee55c3c9a60ec198fe7461fba1f6b30a88b866608e83f47fb1328754b8fe33f3993f8c1ececc89c9ea83cb8b266f36fd9c1b8095946d330e2f"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.apache.logging.log4j/log4j-to-slf4j@2.17.2?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://logging.apache.org/log4j/2.x/log4j-to-slf4j/"
+        },
+        {
+          "type" : "build-system",
+          "url" : "https://ci-builds.apache.org/job/Logging/job/log4j/"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://logging.apache.org/log4j/2.x/download.html"
+        },
+        {
+          "type" : "distribution-intake",
+          "url" : "https://repository.apache.org/service/local/staging/deploy/maven2"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://issues.apache.org/jira/browse/LOG4J2"
+        },
+        {
+          "type" : "mailing-list",
+          "url" : "https://lists.apache.org/list.html?log4j-user@logging.apache.org"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://gitbox.apache.org/repos/asf?p=logging-log4j2.git/log4j-to-slf4j"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.apache.logging.log4j/log4j-to-slf4j@2.17.2?type=jar"
+    },
+    {
+      "publisher" : "The Apache Software Foundation",
+      "group" : "org.apache.logging.log4j",
+      "name" : "log4j-api",
+      "version" : "2.17.2",
+      "description" : "The Apache Log4j API",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "0c39d90e7819c92c111e447bdf786a90"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "f42d6afa111b4dec5d2aea0fe2197240749a4ea6"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "09351b5a03828f369cdcff76f4ed39e6a6fc20f24f046935d0b28ef5152f8ce4"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "8f986171ee6ca94ba8eacfc83b5b45bb87221c176076eb152715fcb4e1f351c4e9f88d56420fc02ee166ebe0b896fb52eda21355dec49302ab3e83a56b245d04"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "e4ba0afbfd91ef295e6c1c1edfa7854e216a29705b5c4b520f803697ae6badf3630c5d55e56394954988fa88e62176b4"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "ef8ecf2f848bcb18790d79b1d4e0fac0582e94f226eb8c7039d7316bd9f4c472556a4052b4a93958eb1248c7a3756433"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "bdcccb79127c28c0f42374eeac65891e7c0d02f18e1469c705e946f74cfc89db"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "14a4d4f38dc5392f378e006994780d686095e1190d476fd18efcd4211bd4dcd64b699d79c5f4351c51f2d26a3ab98b4a49745df6dbd404e3bc981797a5b8c075"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.apache.logging.log4j/log4j-api@2.17.2?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://logging.apache.org/log4j/2.x/log4j-api/"
+        },
+        {
+          "type" : "build-system",
+          "url" : "https://ci-builds.apache.org/job/Logging/job/log4j/"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://logging.apache.org/log4j/2.x/download.html"
+        },
+        {
+          "type" : "distribution-intake",
+          "url" : "https://repository.apache.org/service/local/staging/deploy/maven2"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://issues.apache.org/jira/browse/LOG4J2"
+        },
+        {
+          "type" : "mailing-list",
+          "url" : "https://lists.apache.org/list.html?log4j-user@logging.apache.org"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://gitbox.apache.org/repos/asf?p=logging-log4j2.git/log4j-api"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.apache.logging.log4j/log4j-api@2.17.2?type=jar"
+    },
+    {
+      "publisher" : "QOS.ch",
+      "group" : "org.slf4j",
+      "name" : "jul-to-slf4j",
+      "version" : "1.7.36",
+      "description" : "JUL to SLF4J bridge",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "2a3fe73e6cafe8f102facaf2dd65353f"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "ed46d81cef9c412a88caef405b58f93a678ff2ca"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "9e641fb142c5f0b0623d6222c09ea87523a41bf6bed48ac79940724010b989de"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "0bb1e7343d07d41bcfb0c1ffeb2db28cbb35e7a80a409b80042f463b082a292976f09d719e319471e31c7bab716121728a16509fd385fc6e3b400b1b214cffea"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "50e2f326fc00537a5fb3726c7c55556851b3be8b4346f522f27ddecf2fdb44adabae3197b30ccfd854c37d6734adbd8f"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "4ad0c3870852ac44530a9dcb992d947cd8708ee6f422559da41aaaa8b22d1610fb116b32d2c54df83b110b85487083bf"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "8e3f5aaaa27f618b52e610376d2a16c6f9dc8dce5e6c2bbe42131a590626aae6"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "e3da265406b5e69f02235ed7272a48f71cb8b6f0a696820e28e90fb5eafeeb311abf2a4e779b402f384c6a80470fd41116ee52a526f57040fae3b24cb3b19c01"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "MIT",
+            "url" : "https://opensource.org/licenses/MIT"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.slf4j/jul-to-slf4j@1.7.36?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "http://www.slf4j.org"
+        },
+        {
+          "type" : "distribution-intake",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/qos-ch/slf4j/jul-to-slf4j"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.slf4j/jul-to-slf4j@1.7.36?type=jar"
+    },
+    {
+      "publisher" : "Eclipse Foundation",
+      "group" : "jakarta.annotation",
+      "name" : "jakarta.annotation-api",
+      "version" : "1.3.5",
+      "description" : "Jakarta Annotations API",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "8b165cf58df5f8c2a222f637c0a07c97"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "59eb84ee0d616332ff44aba065f3888cf002cd2d"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "85fb03fc054cdf4efca8efd9b6712bbb418e1ab98241c4539c8585bbc23e1b8a"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "d1acff146c0f9ea923a9325ad4c22ba2052ec474341ab8392abab7e8abd3ca010db2400ff9b5849fc4f1fa5c0a18830eb104da07a13bd26b4f0a43d167935878"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "004a4bde333c0575f72df1cb9cf95ee0c6c7f738a6f0f723a5ec545aaa1664abeb82f01627708a1377e3136754fb7859"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "abcc5b1fbad59b3e9b6d2d6195ec11d6254f689116c534a964724b61f815cca60ba3a2c1489933403f3f78dc54fd20a6"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "3d3ef16365e7a0357d82f874fa26b2b0a146cf7bf98a351c65ef1586444fa009"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "88625a8811be514851209291344df32478b527bc7838ddee58752269bf2457ae8f4e6b6a0d0b5c18522e287ba6df1def0cb19dee2b85e01ee21f0b48ac2630d3"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "EPL-2.0"
+          }
+        },
+        {
+          "license" : {
+            "id" : "GPL-2.0-with-classpath-exception"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/jakarta.annotation/jakarta.annotation-api@1.3.5?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://projects.eclipse.org/projects/ee4j.ca"
+        },
+        {
+          "type" : "distribution-intake",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/eclipse-ee4j/common-annotations-api/issues"
+        },
+        {
+          "type" : "mailing-list",
+          "url" : "https://dev.eclipse.org/mhonarc/lists/ca-dev"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/eclipse-ee4j/common-annotations-api"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/jakarta.annotation/jakarta.annotation-api@1.3.5?type=jar"
+    },
+    {
+      "group" : "org.yaml",
+      "name" : "snakeyaml",
+      "version" : "1.30",
+      "description" : "YAML 1.1 parser and emitter for Java",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "ba063b8ef3a8bfd591a1b56451166b14"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "8fde7fe2586328ac3c68db92045e1c8759125000"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "f43a4e40a946b8cdfd0321bc1c9a839bc3f119c57e4ca84fb87c367f51c8b2b3"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "b00f52326cae804d0dbb48c0ed7f3a98cdebbce9b145f685c616e4049b65183a18e98ca29b7b0275971f9ece52138d0015bb9771902532084cb2cc07a264cfc6"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "aa4f7b90b3a2a83274664f78ca54b523e26ea2f96750c336a8802a6f68fc0842e3e8d36ce4f7e277e7d959aba3bb3246"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "d3cd269127dca6042237f66cf3c3557f87f395d0286712e74da908d11ffb5d4ee7c4960e29e61db346a8376e515d59af"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "4a3c20ddae5c74b381476c491716e01f847e76e28fe82dc46819e9ef122c70fa"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "d1e848c74efd4dd2ba5d4878c0f9df6144926b1d413f44ba2881614cc557a18479eb74c8f1c3392375cc166c94acf2adb7f211f902a7e5acfd7b2966bec70f26"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.yaml/snakeyaml@1.30?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://bitbucket.org/snakeyaml/snakeyaml"
+        },
+        {
+          "type" : "distribution-intake",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://bitbucket.org/snakeyaml/snakeyaml/issues"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://bitbucket.org/snakeyaml/snakeyaml/src"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.yaml/snakeyaml@1.30?type=jar"
+    },
+    {
+      "publisher" : "Pivotal Software, Inc.",
+      "group" : "org.springframework.boot",
+      "name" : "spring-boot-actuator-autoconfigure",
+      "version" : "2.7.3",
+      "description" : "Spring Boot Actuator AutoConfigure",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "194dadf731affb1fea9c1299d2d1e2fa"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "9d32a56377308bce1b02e3fe6832400bfbede14d"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "6c9294ea2537d289e4a0a67ce7af6e36ab3c14f294da2c5fa324bd2a3f654d7c"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "bf67b85d669ac69fc15bb0a1b93dec451673e0949df6bcadfa06352758dc0b3160a34b1202be816d5a9bb212b2054f4f6b61d817981c1fb47a826461bae804f1"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "e2575c7a01e04ad81c2b4f8555155c6b5e639c487ba49be9fb112407e38deffe4288d9f077badb35a101e7dc45ed7242"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "1d280253f73c25dd7697ea3d554b8b48f3e6025b791ed18813bb0b51dfd25a4297ffa0bc9065800194e08111da35fd8b"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "d314377d890fc0bb40e38085e01fcb904d86ba4b30a52e14f2ae0ef08ee0f121"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "3f2bf176f8512bb8b36b0caadcdcb9ee59c19fad38b4d3e48de0f7b61caf4b7f89b741ca4f1ac599c0a8b7831eae277eb36bd64d535655157f939c73acc8d0d9"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.springframework.boot/spring-boot-actuator-autoconfigure@2.7.3?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://spring.io/projects/spring-boot"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/spring-projects/spring-boot/issues"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/spring-projects/spring-boot"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.springframework.boot/spring-boot-actuator-autoconfigure@2.7.3?type=jar"
+    },
+    {
+      "publisher" : "Pivotal Software, Inc.",
+      "group" : "org.springframework.boot",
+      "name" : "spring-boot-actuator",
+      "version" : "2.7.3",
+      "description" : "Spring Boot Actuator",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "7344030215ef49cf258c5b7017cfb386"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "a991796db5d89f9014d87a307208badffc40bcca"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "4c9cdf875693d16e4b70d5fea86533374b64bbf66ad2a8e6ca9dbb0a36b71b95"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "a52a632b89f4c59e4ffe21bfb99dda7f9e9f41545505d51ac019821ee3d1541c6379d0a2e7f5e81550f9815e35fbd25c19532a300b8bc11c04d1c1a90b6b9538"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "0d886200dff99bee5a88d901fc04bffa35a6325b9644c7cb4d1645638aed23583e36f605e6e2fad8d715d806ff29df1b"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "b721d26f4993c86297833d0f6d16d923f7dc256aabf77727819dbc8c032377f6cce77ff384942185f68eae26d507782f"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "001e04b2f80ebdfc7716f20d3b4d0f3f267a6c21aa7af4bc9f83ad6886726474"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "4db23322692257031154a4a4a6d66704ca10918a071c4d20e679c411719a5b7ed7169642994e4a8fe3eae4e55037ebac3de27dedec579eab0536e97f44cf539e"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.springframework.boot/spring-boot-actuator@2.7.3?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://spring.io/projects/spring-boot"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/spring-projects/spring-boot/issues"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/spring-projects/spring-boot"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.springframework.boot/spring-boot-actuator@2.7.3?type=jar"
+    },
+    {
+      "publisher" : "FasterXML",
+      "group" : "com.fasterxml.jackson.core",
+      "name" : "jackson-databind",
+      "version" : "2.13.3",
+      "description" : "General data-binding functionality for Jackson: works on core streaming API",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "e35e2adf33b2eed8e9f538a911244175"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "56deb9ea2c93a7a556b3afbedd616d342963464e"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "6444bf08d8cd4629740afc3db1276938f494728deb663ce585c4e91f6b45eb84"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "dd6daeb7481bab4641adf71552774dd143039dc856aa6e3e5805c1964fecc69eb18a2fd8201e16ebebb92549edb7f10d1f9a50391ed9a120f867b675a6d4d4ff"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "38a8c81bc7a37315428697ab761f4c12b409046247414532fc68e37bb2a70e0d0a50b555dd20a251c6f63a85dfe536bc"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "27936164e28773f942663edb22e1022bcf061ab1b4afcb45e6705b30a4e17cd668066edc094a8bd8bc44b82852313909"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "e3f1bca51b619ada05e6a4f88ff37d65625e9fb9e5a4b3c017834c6594c964bb"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "cc93eb45e2c1997db9b78b38db68f2648493c1ea79932ad076dfcbc5e5edfd8015798ff5d99a9f06f9e7dca745c53406b8954ec1ffc626a61ece429c30a06f47"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.13.3?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "http://github.com/FasterXML/jackson"
+        },
+        {
+          "type" : "distribution-intake",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/FasterXML/jackson-databind/issues"
+        },
+        {
+          "type" : "vcs",
+          "url" : "http://github.com/FasterXML/jackson-databind"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.13.3?type=jar"
+    },
+    {
+      "publisher" : "FasterXML",
+      "group" : "com.fasterxml.jackson.core",
+      "name" : "jackson-annotations",
+      "version" : "2.13.3",
+      "description" : "Core annotations used for value types, used by Jackson data binding package.",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "3fb8ee542a62a113fa7474fe88bb97e8"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "7198b3aac15285a49e218e08441c5f70af00fc51"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "5326a6fbcde7cf8817f36c254101cd45f6acea4258518cd3c80ee5b89f4e4b9b"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "7f89b142068879b5fd96e4cb947313b3b39c1dbead43480307360a212fdb5347046b14fbc9b94c480034a4826fdd2a821686ebd121d774d55795326eaa1c95fd"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "245c29f5dff5e7677c7f614df69de1072dbb56717fe88890128dfd6479994bb9a81a9917d41a2831a9a96e6d12aa3bb1"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "14086ba58917fddf8b86e16db4a865d6550c3368e7c4ac11f14a29e60165c1a85cece76c03fa046ff6482af4c96618bb"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "69aa8638b7dee54ed7d676e90054977ffedc0e7e19acd82ae6a2ca28ed706b03"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "74121eb8b75529ebf01a8af81348efa889a9d13914620c95c23548a4dc42babac9f33556b0f668c66610f95db5854ced45fc5c0518147ec233af37213aa9c858"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/com.fasterxml.jackson.core/jackson-annotations@2.13.3?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "http://github.com/FasterXML/jackson"
+        },
+        {
+          "type" : "distribution-intake",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/FasterXML/jackson-annotations/issues"
+        },
+        {
+          "type" : "vcs",
+          "url" : "http://github.com/FasterXML/jackson-annotations"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/com.fasterxml.jackson.core/jackson-annotations@2.13.3?type=jar"
+    },
+    {
+      "publisher" : "FasterXML",
+      "group" : "com.fasterxml.jackson.core",
+      "name" : "jackson-core",
+      "version" : "2.13.3",
+      "description" : "Core Jackson processing abstractions (aka Streaming API), implementation for JSON",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "9a6679e6a2f7d601a9f212576fda550c"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "a27014716e4421684416e5fa83d896ddb87002da"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "ab119a8ea3cc69472ebc0e870b849bfbbe536ad57d613dc38453ccd592ca6a3d"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "d5337db908b2c56dcb911e3d1a5f671456c13f254fe8d2a620823bc15b2db6aaa8325a86b436b5d181f2584b533158fd14d140b98305ac252f8dfd9a627da859"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "7b96a15f15eb9a44795c632313503677e0e65615d31922861138ee059defb1db31dbd98144a6474c25fa69de1c60f7d7"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "da78b678f4ebdbc9f61efd9475b67d35dc7ff5f2aa80bedaed8e9fbeecc2a96f2c793009abd1e4d5f27ae8fd2a81ad7c"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "4511d609261102f213a9704d71541f813360699b81c44ec795a8fb88bd087daf"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "e0d26e27d5d8920a856c7e8be48236bafae837994da1f8daced1078a1acde2ff1007e2849c9b007365e67541e1e881a18c1f7c66ed11fbc9fcdb91b8ea69dffa"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/com.fasterxml.jackson.core/jackson-core@2.13.3?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://github.com/FasterXML/jackson-core"
+        },
+        {
+          "type" : "distribution-intake",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/FasterXML/jackson-core/issues"
+        },
+        {
+          "type" : "vcs",
+          "url" : "http://github.com/FasterXML/jackson-core"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/com.fasterxml.jackson.core/jackson-core@2.13.3?type=jar"
+    },
+    {
+      "publisher" : "FasterXML",
+      "group" : "com.fasterxml.jackson.datatype",
+      "name" : "jackson-datatype-jsr310",
+      "version" : "2.13.3",
+      "description" : "Add-on module to support JSR-310 (Java 8 Date & Time API) data types.",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "2b0c7790f2e820c5c9e4a9737097d256"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "ad2f4c61aeb9e2a8bb5e4a3ed782cfddec52d972"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "5a2489b4c08ed7a7f132b43789b604e9186695b17f04f3fbc935a62c415b34a3"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "826e480799a2a6ee0fb7f34a29aea44adf24ff02fea1b3943d3761272c0f76ba52e12413905e3a903b0aa904718b09befc5c63543c604addbbaaac4eb15d16da"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "7ab0a6de658dd40f98373f8859b3b36534593075b97e83ebde9f51e97df2cb97aeb633c7ccce6a41beba0918d97f81e9"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "2bb1b2a023e60263db0aeb47bfeabb54d71df66cd6eb4bf7ed6919d6fb33bc7d21d673b9f49cadbc4586e2caad36bfa4"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "2f3c426c2e4f120d54563e463a23ecdd550751e85282d78457fd23cb43beb87b"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "9b3f84921b04a3bd44257a31990dee3f00e887fbfeab1a8e8aae84629bf465d45ccbd869ba6b074bd6024b7f654d23079acefb2ff66d4ee321969574291a9f2c"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/com.fasterxml.jackson.datatype/jackson-datatype-jsr310@2.13.3?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://github.com/FasterXML/jackson-modules-java8/jackson-datatype-jsr310"
+        },
+        {
+          "type" : "distribution-intake",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/FasterXML/jackson-modules-java8/issues"
+        },
+        {
+          "type" : "vcs",
+          "url" : "http://github.com/FasterXML/jackson-modules-java8/jackson-datatype-jsr310"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/com.fasterxml.jackson.datatype/jackson-datatype-jsr310@2.13.3?type=jar"
+    },
+    {
+      "group" : "io.micrometer",
+      "name" : "micrometer-core",
+      "version" : "1.9.3",
+      "description" : "Core module of Micrometer containing instrumentation API and implementation",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "f12d64e8e660e137a4b771967e22e375"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "5b3bd8971b0f687c7f820d2b0b631fa97850ed94"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "aba15a90750823a41fc121452b250483ea10c2b8991b3e3ea3ac0ffe291025dc"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "185628c937f092a66e3722f07decb5fcb53112bbbf90365813d3266e77933b334427408d9d52904dd1ca567a6ef1c27a6dde7099ca9514f61a77837db785d146"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "49da5e0b4de50a7554af9f50dedd80446e14e615e8f515b289919cd374c71c90ef8ffe12ce681ed3d0fe7681acefb78e"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "eeb5452b45eb04188f4ed4fba00cb7df4de5ff2bd95cd8ecbc5f9d3a022096d8cc5da520aaf4d8d65abc54f6c1b85e05"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "b96938630e528a02c948ff31e84b1bf55026b68b971f3aa356ea0560348567ad"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "6eb74036d47a8cb8cf7262346693d6a49563efe8f09eb0fbeb12e20faf14977f6aea0498986b9f4ffa6effc16bb228cc4348e37fd59bb8cb2fd0ea0531b0ab38"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/io.micrometer/micrometer-core@1.9.3?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://github.com/micrometer-metrics/micrometer"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/io.micrometer/micrometer-core@1.9.3?type=jar"
+    },
+    {
+      "group" : "org.hdrhistogram",
+      "name" : "HdrHistogram",
+      "version" : "2.1.12",
+      "description" : "HdrHistogram supports the recording and analyzing sampled data value counts across a configurable integer value range with configurable value precision within the range. Value precision is expressed as the number of significant digits in the value recording, and provides control over value quantization behavior across the value range and the subsequent value resolution at any given level.",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "4b1acf3448b750cb485da7e37384fcd8"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "6eb7552156e0d517ae80cc2247be1427c8d90452"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "9b47fbae444feaac4b7e04f0ea294569e4bc282bc69d8c2ce2ac3f23577281e2"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "b03b7270eb7962c88324858f94313adb3a53876f1e11568a78a5b7e00a9419e4d7ab8774747427bff6974b971b6dfc47a127fca11cb30eaf7d83b716e09b1a0d"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "06977d680dafd803d32441994474e598384a584411a67c95ab4a64698c9e4cbd613e0119b54685cea275b507a0a6f362"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "b5ccb4d39bf7cc8ccc33f0f8fcbab0a63c99a94feda840b5d80fc3ae061127f1475cfb869b060933783a1f2eafb103a1"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "ef2113f27862af1d24d90c2028fc566902720248468d3c0f2f1807cc86918882"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "4fca2f75bdfd3f2ac40dc227ae2ef0272142802b1546d4f5edf9155eaeed84eff07b0c3a978291a1df096ec94724b0defb045365e6a51acfdd5da68d72c5a8eb"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "CC0-1.0"
+          }
+        },
+        {
+          "license" : {
+            "id" : "BSD-2-Clause",
+            "url" : "https://opensource.org/licenses/BSD-2-Clause"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.hdrhistogram/HdrHistogram@2.1.12?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "http://hdrhistogram.github.io/HdrHistogram/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/HdrHistogram/HdrHistogram/issues"
+        },
+        {
+          "type" : "vcs",
+          "url" : "scm:git:git://github.com/HdrHistogram/HdrHistogram.git"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.hdrhistogram/HdrHistogram@2.1.12?type=jar"
+    },
+    {
+      "group" : "org.latencyutils",
+      "name" : "LatencyUtils",
+      "version" : "2.0.3",
+      "description" : "LatencyUtils is a package that provides latency recording and reporting utilities.",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "2ad12e1ef7614cecfb0483fa9ac6da73"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "769c0b82cb2421c8256300e907298a9410a2a3d3"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "a32a9ffa06b2f4e01c5360f8f9df7bc5d9454a5d373cd8f361347fa5a57165ec"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "bb81a42498c65389366205f4e07cee336920e2f05cc0daae213f2784b1d0ce9a908b038daec20478f23eb00b2bf704f96c5b00f63c99615193ab2a3cc4a9f890"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "16ca4640dc9d848e6c6d15441897e1b5a9f27f34207b0bb456dd54d8f267b73b348092e548e78634144de44ba3515205"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "406c2b5c6f64b0c090568e479b5e6136a04a4e77f8eea65d32b4e2b01deebcdf6a0a851240cdb740c25b5a5e61e6c179"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "50ae828358301033542fd7c412e86ee318d5451f89a182e2a679aaf18099d26d"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "456c337b9fb385579aae707409ed6a04d08e5fc87b1a46733dca617c22c625bf253dc4747e0cdbf5e7d8b48102d2938cb482b6b688a79aab645a7459c592258f"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "CC0-1.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.latencyutils/LatencyUtils@2.0.3?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "http://latencyutils.github.io/LatencyUtils/"
+        },
+        {
+          "type" : "distribution-intake",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/LatencyUtils/LatencyUtils/issues"
+        },
+        {
+          "type" : "vcs",
+          "url" : "scm:git:git://github.com/LatencyUtils/LatencyUtils.git"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.latencyutils/LatencyUtils@2.0.3?type=jar"
+    },
+    {
+      "publisher" : "Pivotal Software, Inc.",
+      "group" : "org.springframework.boot",
+      "name" : "spring-boot-starter-cache",
+      "version" : "2.7.3",
+      "description" : "Starter for using Spring Framework's caching support",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "ff11940766f88179cae0cf5836179d4f"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "1484c8f477b7a7d27b50810c1685ed3e21564a1b"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "8283c804a71bc6f010cf1acbf76a642cb0f7fdc46d7deced0a3f5251e3feede6"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "8457800afee02b89048332e2cec06540e810828e963e1088b5f7df3d637a99ac3997293d74b821a150942b96ceb29d7dd99ffeb855ea9a870e1a19585df0d961"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "1f59a6f88b361e371057a4d3ef582de52d80710ddbe08ee0cd92d0d08ac56a7ebdc6422c649a836b305b22e2e30cc94b"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "16529e06bc8534c4d37f2f53a25ed2d85cd511b10a0d860176ace53e54c9b1ee3ff33a147c8d53f74954ad5abb997870"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "dad4baed1981432b9b7a4b743a93bef1a80dbc81efa1b0d5929a4a3328a63a9b"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "334721932a5fa661df781a4f023a282bc3a32df60a03b29ecfbb29e12f6032dd8786cc93071f3f77d18ccca0c7bd830ca5f0d82cf23bb9e2eb939226fa205be9"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.springframework.boot/spring-boot-starter-cache@2.7.3?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://spring.io/projects/spring-boot"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/spring-projects/spring-boot/issues"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/spring-projects/spring-boot"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.springframework.boot/spring-boot-starter-cache@2.7.3?type=jar"
+    },
+    {
+      "publisher" : "Spring IO",
+      "group" : "org.springframework",
+      "name" : "spring-context-support",
+      "version" : "5.3.22",
+      "description" : "Spring Context Support",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "454eb9b0d7a6f5cdbdb72f88d4b2ae88"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "3276aa68e9bc453063fc19d81d780cb05d6cae59"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "752bcb6868ca06a5fe5ea42bac34f8b029acb3f5c0e4bb8fce20d3a1b17ac28f"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "28c628bb6dd6992034b3598696879bcc64c2e0efe54c5ee5dc1351f15553867d0ed17b1568674fc8976de580451b0ea2bacca63241f5eca8e26495e7450ea3db"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "fec1f0050e3015e2c3e101dad9b67f1ecff93a276660286b87cabbfc4588519c188c31addb0d3609770d91d124de2004"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "476dcad94b4f57322c7f775c036641a16877975fcc7d1f96c67b8fcf3f383fa47c83e3527b5439b3c254ae64a7eae0fd"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "f3ab36ad9f73ceaf36aeb5a995babba46df96be78762bbc27ba141f76368c8cb"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "3bef19a528792ec96f4c3aa54d77ed9d80addf6a19356fad3b61a72dc742e1af82d3625c10937cc486d8b12101ee273c57e79628467e59bb91b03a4911aa5b33"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.springframework/spring-context-support@5.3.22?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://github.com/spring-projects/spring-framework"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/spring-projects/spring-framework/issues"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/spring-projects/spring-framework"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.springframework/spring-context-support@5.3.22?type=jar"
+    },
+    {
+      "publisher" : "Spring IO",
+      "group" : "org.springframework",
+      "name" : "spring-beans",
+      "version" : "5.3.22",
+      "description" : "Spring Beans",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "254c6d03b5b6164328329a188267291f"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "866c2022b5fef05b1702f4a07cfa5598660ce08a"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "4adff173a6f68ffc5a5333c8c8a37d10740b0cc124f9aafaed88a3a8ca431ca4"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "c7ae00ed34ac16fe8ae27c055896b9c2bd24ad61a08d49d25830efcb09bc5057b77bf21481ceebe63ee6f2fb70e067ea4fa4f5c926d1c1ecd396ff67a9bad14e"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "df7ed3d3e9c43ab019937b0a82f25f69cd48fbfc00cce90f41ef35c2a54aa0a68acfd891fb341b67ceba6d12c265abc1"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "e1927bdf3720a6dd80996b09560de44fadefdef40d066c671ac544f20e3b80bbeb25984ebda4fb4184771f1e84a39ff9"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "e3b45a00cae7db372ea1895d1c8d69a7d972e6864d005ab599b7147e86652f6e"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "0006ac720888aeef001f8ec6f4034e6143c80517f00bfba4106f802edaed815ec75e27a5c0138b50f992e7c1437496f66b002507f15fef9e1e504ee6c8ec9a27"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.springframework/spring-beans@5.3.22?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://github.com/spring-projects/spring-framework"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/spring-projects/spring-framework/issues"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/spring-projects/spring-framework"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.springframework/spring-beans@5.3.22?type=jar"
+    },
+    {
+      "publisher" : "Spring IO",
+      "group" : "org.springframework",
+      "name" : "spring-context",
+      "version" : "5.3.22",
+      "description" : "Spring Context",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "3b00971f0b99194b13d5762ca319b9c5"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "fdd59bb4795c7a399e95ec4a5c8b91103e3189fd"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "e7f9c4727c98aaf02542056f1c2c504dcdb4478f75c4baeb81ab15059b7552c5"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "007ddf6f0a88e20f336dacefc05cae15e0f0eb4a87baaef9232a9238c81168532e80850c0d02ef54554bd9fc8d22fd6f2ad977a6733b76c2a090fa8baa47d6a8"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "ae7c7ffe588d5e7bd29d5f5d1e75b11ad4488af3a420663fa206c281d2b3891d75bc4a1940e8d7e9b6ec4186502fc565"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "f29f84ff386cdc2dab5a26ea2bb21fbd753bfccf4e84ed16402ce1e2c6ec7b80fde982c5642c4d73099e919fa36579b0"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "c8a80d2dbfdbdb0e22cab06df80ce1ef88e7e5def7ab6b1819778a891dfd886e"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "a806426d7acd4ae652262579aae31d85c348e48ae3da9fc69c00de12bb121a73a0de9ce4f24681d629e557b54432df51caef0377b7e5762e5937da01a920d088"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.springframework/spring-context@5.3.22?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://github.com/spring-projects/spring-framework"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/spring-projects/spring-framework/issues"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/spring-projects/spring-framework"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.springframework/spring-context@5.3.22?type=jar"
+    },
+    {
+      "publisher" : "Pivotal Software, Inc.",
+      "group" : "org.springframework.boot",
+      "name" : "spring-boot-starter-data-jpa",
+      "version" : "2.7.3",
+      "description" : "Starter for using Spring Data JPA with Hibernate",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "5f79d2d0132abad21b96371b310b3c5d"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "23f7118584200cf9edd43140dc6252679047bee0"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "511eb0516e3f26c76fa0a7f6831d3638681b00d782c797034fdd205fc399fdd5"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "c511ebe36644135469b4b2956087459523434f1dc4631a3ee6b26ab216caaa72a247b8ebc2f36195a74476d19c4fa5aaedd327c729e216abbf81e3b5d2280f97"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "b3d4cd1139b26401bf4635a3ca730b45b5d36afeb17aac3f2c317be838f92c13f4c4f6ba5fd31934a5b3afa249b3701d"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "30bf86ddd1c706025d2a22346d98b4ae698f42f2b9131a2be69444b7dcd0c1bc149c3270fc2c4452624287f2f13e18d0"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "84ce5b1a1bff9eda9ea13cf5bb2e03df7d066c887b65e5bc934a82799302f149"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "0033bc7a315f31707584cdf1f9ee37505172f11d3d7bf69e6bb55251fb9a5182951dd6cffd24285153341a0a72b45f79335e7a1b626ca4bc7c14fe2ff9ae7765"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.springframework.boot/spring-boot-starter-data-jpa@2.7.3?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://spring.io/projects/spring-boot"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/spring-projects/spring-boot/issues"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/spring-projects/spring-boot"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.springframework.boot/spring-boot-starter-data-jpa@2.7.3?type=jar"
+    },
+    {
+      "publisher" : "Pivotal Software, Inc.",
+      "group" : "org.springframework.boot",
+      "name" : "spring-boot-starter-aop",
+      "version" : "2.7.3",
+      "description" : "Starter for aspect-oriented programming with Spring AOP and AspectJ",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "116bd0d65ac976dd52a3018e88a5c871"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "b2806bdfae4cff6b82a174a68984a4cedd2d83f5"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "a4d54afee8860a0ee0c437d5757fc9b47c71a5a0aa3925e585f981d79f73e943"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "acaee6dbac69818c329bef27b7fbc8cded7a3a9fb9b389700c2a83f0bf5554820b035afa7a3836b8d417e37042be36d5b65425f8a24cd68ed6c6d1341e8475a8"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "bbc2d573cdb61865f176b4220246ed6a490bca333cde731143143314dde5718b2f3710ee3575c759651706831dfbe685"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "313e0e3e397fc8a5f20bff44d097375aa11733bb1b14c8fd4f4762bf4ddc4901098f93c66604e93bfe7355543322a8a2"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "60f99a14c20c0bd35a2e897efae603944682191d5882acb2afb3535ca31ad707"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "c81771dcc508f80dc3e9fd6a87487874c27142f77ed63fdbaeea3f20378e1020098e418be8cf008f7f9023b39f94061dc8dccef31e21ce2bae772ec87bacd030"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.springframework.boot/spring-boot-starter-aop@2.7.3?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://spring.io/projects/spring-boot"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/spring-projects/spring-boot/issues"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/spring-projects/spring-boot"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.springframework.boot/spring-boot-starter-aop@2.7.3?type=jar"
+    },
+    {
+      "publisher" : "Spring IO",
+      "group" : "org.springframework",
+      "name" : "spring-aop",
+      "version" : "5.3.22",
+      "description" : "Spring AOP",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "8f59cdaf80f1836a9631b3e3c8513cb4"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "2f9f00efbff8432f145ccffeb93e6a1819bac362"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "52c0efeaa4528e30b805bbd3d908281d8488e487cd2a45d8e4d7b591e6b08e77"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "5e7be423124c37351400833fe713c0ed483815f0b52f25f2cb9bf8980214bdbb9fb982680d26f0ec0b5fc2562636d7bcb61fd537f00533469f48d942d827d9f5"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "b43083391588b48f9b63acbb9a89a45f0a0aec3d18e37cbb299093adc73228f15290c90948930a0d62ea42030ebc102f"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "fff1ebcca8aab16ee4247548e54aa7de962af72ea2e93878adf5cada697eca79597dfcff847c881c15d6a76514d97d92"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "11f31d85aee8939a9f877cee143914d5f0e6e8e7644e16334bac6ece4eb5481c"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "e0132069cd4a02fab061f100ddad98b8a3c0bc7be87d3c970d39a4bdbdbaf74e93ad8091b4fa8fbfa6d4165e9b2f4f2738c8a5a470870cb2e9fed079d913159c"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.springframework/spring-aop@5.3.22?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://github.com/spring-projects/spring-framework"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/spring-projects/spring-framework/issues"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/spring-projects/spring-framework"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.springframework/spring-aop@5.3.22?type=jar"
+    },
+    {
+      "group" : "org.aspectj",
+      "name" : "aspectjweaver",
+      "version" : "1.9.7",
+      "description" : "The AspectJ weaver applies aspects to Java classes. It can be used as a Java agent in order to apply load-time weaving (LTW) during class-loading and also contains the AspectJ runtime classes.",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "a4d97c5a2f94b8b5d132761a769e5eeb"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "158f5c255cd3e4408e795b79f7c3fbae9b53b7ca"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "1b448d82bd0f8a8c1842506e6c7edb95ff1a1275ce39f766e7884122b866fe5d"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "490fcf238486848e27cbed45fd437613193c9e89748a0818fb532aed5c213aab2624d148ed9fd58080c6934da5f7ec12c64e40b64bb46d16e361eb404393c5ba"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "4d3b13d7e7ab437410226974ad3acebc8c663b21d9ccad6d70b5adede33bc4033858e8b303c7263a8e17c073c354b87b"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "0d56981fa691d1d79f39aa65dc091def5fb106f65d5d1b0836a7279b95195961c5a49f07979cda49e35768276a30477d"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "e10b7535b50a0017f062b7eb71f1f1b301beadfe474d050f7100996797a8640c"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "a77467b7b04410e7eb33214e84b4061f3e7112eb4c29a2c826691bdc0af6136c7a78789ae685273e9e69cfb40e674b64ecb31d1e516a8b5d79afefb13f57ffa1"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "EPL-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.aspectj/aspectjweaver@1.9.7?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://www.eclipse.org/aspectj/"
+        },
+        {
+          "type" : "distribution-intake",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/eclipse/org.aspectj"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.aspectj/aspectjweaver@1.9.7?type=jar"
+    },
+    {
+      "publisher" : "Pivotal Software, Inc.",
+      "group" : "org.springframework.boot",
+      "name" : "spring-boot-starter-jdbc",
+      "version" : "2.7.3",
+      "description" : "Starter for using JDBC with the HikariCP connection pool",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "1c9aaf8e52bdfc883ab2797fc83355d9"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "c5cfc6efad06811d5dd916e86c97989b08575b31"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "8e8d6c65390a835b9c0a529d702c9508c877e52d526f709932be6963f2a269ea"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "44ceff94410acf1f6664a93e21f2fdac1168745f85850624065f713a514fa99e4b8c6e7f958b0b1a81b89f81e2b6660cfb0fa8367fbea1ce5031cf820fd289ae"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "fba77727bae7dd0cc74f45f77e32b391d25f65feff9bab8d26b7fa0446595752c72d479c5beab5e8bface1d3d2163961"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "72e7b5904e285e52e296a7bba3540765cdc6e16eea9573528e38bedf2a692dfeddd0b54a27a3e8d5da3d2468bb13afd3"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "efa71e0df44854a38214bf89e88356d2f9623b3824c04329e14c2ef30dcac9c0"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "8c657307459cb58654933852c0f8755fb4446e3c0866739363517a0df2ae870d339c5fee02621b6a0743a19f2057cc6b7f2ce6250bbfe186ab64002e9fbdc19a"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.springframework.boot/spring-boot-starter-jdbc@2.7.3?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://spring.io/projects/spring-boot"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/spring-projects/spring-boot/issues"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/spring-projects/spring-boot"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.springframework.boot/spring-boot-starter-jdbc@2.7.3?type=jar"
+    },
+    {
+      "publisher" : "Zaxxer.com",
+      "group" : "com.zaxxer",
+      "name" : "HikariCP",
+      "version" : "4.0.3",
+      "description" : "Ultimate JDBC Connection Pool",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "e725642926105cd1bbf4ad7fdff5d5a9"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "107cbdf0db6780a065f895ae9d8fbf3bb0e1c21f"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "7c024aeff1c1063576d74453513f9de6447d8e624d17f8e27f30a2e97688c6c9"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "34a9ee96c51ae070634cd0b642cad3c4c54b9d2ab7f1714f59dad805512ae27c9c69b8be83da473689f55474c4e2874c93e727f9f31d3bfc9b80ec37aeb68898"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "9c49efde42b89a8cd2b119d666076bc9d532c4a835c640b77d8a5858d3325f9ba99f8cd19cd21b9df4f386d1c21855ae"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "ccea43e68e6dcf0426c271640abf132575a9e28b439ac968b5608e3d04d7ec80dd948d33c474e31fb18bab9b80959c2b"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "163e0d75894a0a4c2d36f4a992449e2dfd71bf495f5789813cd333ad1b571fc5"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "bc20907f677b6fceaf8f81361d5a7e0099799561af550a2a49dfed531a3b8ee29f35ecc2c4419cd8eef9e25a147a2cf88cfb7ffc9218b8b35b0e0524caf56d8d"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/com.zaxxer/HikariCP@4.0.3?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://github.com/brettwooldridge/HikariCP"
+        },
+        {
+          "type" : "distribution-intake",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/com.zaxxer/HikariCP@4.0.3?type=jar"
+    },
+    {
+      "publisher" : "Spring IO",
+      "group" : "org.springframework",
+      "name" : "spring-jdbc",
+      "version" : "5.3.22",
+      "description" : "Spring JDBC",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "929ad2882685e0d809e59a0aa194a3a5"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "d50fc708ef9bade1d3fb64d529b8ff8cd5b625ba"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "a7fc8bf8bdc74dc5bffd9898844409afde38a88421ff45123f2147be1c2c7099"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "d1cd08794f203dc6689ee934b93bbadcebc2bf1defbde53b612618124e892620ad1aa1efc514b50770e69d03937ca25d61d0d294207ac31fe65774bf343ab669"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "743d9b61a991c86c0c86fd5cef0e84c37487c20b7dd07b2c329548d103858c74131efb3d72591ea20cd00c759b6b3094"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "a1bdda275b42099583ba071f705d08db625ad597cd1e715483af7ec8575fa8d1061cdca0a243b8b42aad3330deacd7b6"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "b64a2211cc71eefa26dc504e715de50910b14f98f1c9420a938cb5dced7f7347"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "8aaa08e47e02e0caca26bd036c2a0f51b75fe05e06ad9a9c5d41df65626ecbfaf68e40b5cd01abd3593ad3f9326e1ec3bb5eeb6f820e3af9e97e4b5aed367f5a"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.springframework/spring-jdbc@5.3.22?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://github.com/spring-projects/spring-framework"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/spring-projects/spring-framework/issues"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/spring-projects/spring-framework"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.springframework/spring-jdbc@5.3.22?type=jar"
+    },
+    {
+      "publisher" : "EE4J Community",
+      "group" : "jakarta.transaction",
+      "name" : "jakarta.transaction-api",
+      "version" : "1.3.3",
+      "description" : "Jakarta Transactions",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "cc45726045cc9a0728f803f9db4c90c4"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "c4179d48720a1e87202115fbed6089bdc4195405"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "0b02a194dd04ee2e192dc9da9579e10955dd6e8ac707adfc91d92f119b0e67ab"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "764ade8ba807682dcd1ec7382c35275f3d8ab09a03d5b45c48e732501190e2738269080aaf28aa8dd656c11ee84bfb7dae6953dd2768f2acecd3a8cf0ca4961e"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "63adeb3c5eb24ad0147377436b6e3208d5e97c0e800e0e1e4cb3ba92699f1b06034c2ba00e3689aa8f909ee96c432db0"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "dd0a253f45dac003d40ebeed7f38b0850ff4b08941d55db5b3bbf4c936f94062d23799729ff718c54a565de2482bfd3d"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "d47afbaf1daba46c7aa107bf1b476857523738370309394958f96a2105686684"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "1b744b2d939a8d0a2bbd0be29c717af4a5e2374ca26fbb95a16df03aa55d2aa092e9314f20d5b080f02030ae1b70e4904ef0f8e1509680b9001153cdb7bc1934"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "EPL-2.0"
+          }
+        },
+        {
+          "license" : {
+            "id" : "GPL-2.0-with-classpath-exception"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/jakarta.transaction/jakarta.transaction-api@1.3.3?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://projects.eclipse.org/projects/ee4j.jta"
+        },
+        {
+          "type" : "distribution-intake",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/eclipse-ee4j/jta-api/issues"
+        },
+        {
+          "type" : "mailing-list",
+          "url" : "https://dev.eclipse.org/mhonarc/lists/jta-dev/"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/eclipse-ee4j/jta-api"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/jakarta.transaction/jakarta.transaction-api@1.3.3?type=jar"
+    },
+    {
+      "publisher" : "Eclipse Foundation",
+      "group" : "jakarta.persistence",
+      "name" : "jakarta.persistence-api",
+      "version" : "2.2.3",
+      "description" : "Eclipse Enterprise for Java (EE4J) is an open source initiative to create standard APIs, implementations of those APIs, and technology compatibility kits for Java runtimes that enable development, deployment, and management of server-side and cloud-native applications.",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "e0a655f398f8e68e0afebb0f71fba4e5"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "8f6ea5daedc614f07a3654a455660145286f024e"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "0c2d73ab36ad24eeed6e0bea928e9d0ef771de8df689e23b7754d366dda27c53"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "1e07257b631ae3331a71d7cd9136152cddebbe786ba50c689bec618a9eb659be8e952fe0405db36332cb6c12c6c87c6d648e817c027ea8c6e0c660ce82f6f424"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "d68e1f600244d7a3628244e0265208ce08881f4ea33a3cd1f085886f7ce755cdd44bc6788ebda1baf8bc23b1f3c844dd"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "fb77e58872d4e3ef6475094ea96f1ce32a1a7c3617393fcab47c47cb84f6995315c5f805d518c69a0cea751ce980bf13"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "3619596135b169649ed16b75972c39614192d2a802291a7eb4c1814ef7dc9ff8"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "045c7f1ec7f9191cd2ff35fadf5c037aa596a288189185fd10d5fed89cd3661b6353945083f4c3943c87e343b61a556699f43f00a0e928c165e52d57fe514fa5"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "EPL-2.0"
+          }
+        },
+        {
+          "license" : {
+            "id" : "BSD-3-Clause"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/jakarta.persistence/jakarta.persistence-api@2.2.3?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://github.com/eclipse-ee4j/jpa-api"
+        },
+        {
+          "type" : "distribution-intake",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/eclipse-ee4j/jpa-api/issues"
+        },
+        {
+          "type" : "mailing-list",
+          "url" : "https://dev.eclipse.org/mhonarc/lists/jpa-dev/"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/eclipse-ee4j/jpa-api.git"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/jakarta.persistence/jakarta.persistence-api@2.2.3?type=jar"
+    },
+    {
+      "publisher" : "Hibernate.org",
+      "group" : "org.hibernate",
+      "name" : "hibernate-core",
+      "version" : "5.6.10.Final",
+      "description" : "Hibernate's core ORM functionality",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "9c4f43fc5936b6d6555ff6ece7865220"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "408fd5802391d8e6f619db9d7c6c0e27d49118c2"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "ed3693a0ae288dafff6155b03b7d743fdb9c9f432de37d7b894f44d92e3a85c4"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "8a6c11bbc9ae9768a9f54fdbef278ac69dcfaa848cefa3ac1b2f56ca0c93323f2ed61be576b13312cec780172666af5038e4b89a322a77859df83929e7124f5d"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "25690c68444a2c5d9a2b74fa2a811c1c424962de7dc94cd00c0b147c4f0af58f247b0ea5ccac004fb31e80f10e95c3be"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "4d5075e0738030ac3c991210115c42adc5b9108a23520bd129ec1e1c2afbf74d1d06dfa26d70549bad4b93bf4aea359a"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "833621051c7bebba299d96ca022f65ea36f64d9da1f28086288685d9a18b7590"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "77bfd3bf5fb4a7bdddd9e63bb90d70910dabb04585e50a124c1495b24d2bfe5d40758fb6c298ed5fcca19f8a94b3082419afc6f734764aa552e3e8c947a950f1"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "LGPL-2.1-only",
+            "url" : "https://opensource.org/licenses/LGPL-2.1"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.hibernate/hibernate-core@5.6.10.Final?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://hibernate.org/orm"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://hibernate.atlassian.net/browse/HHH"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/hibernate/hibernate-orm"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.hibernate/hibernate-core@5.6.10.Final?type=jar"
+    },
+    {
+      "publisher" : "JBoss by Red Hat",
+      "group" : "org.jboss.logging",
+      "name" : "jboss-logging",
+      "version" : "3.4.3.Final",
+      "description" : "The JBoss Logging Framework",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "b298d4b79e591843c1eb1458ea79f070"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "c4bd7e12a745c0e7f6cf98c45cdcdf482fd827ea"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "0b324cca4d550060e51e70cc0045a6cce62f264278ec1f5082aafeb670fcac49"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "60759c4340a7c1af0f10a5c2252e028150413d2437547f42018a94a838dc4a2bb24256411490a7e5f109b76305e2752ecf37def85e631d7e7b7e8461e0b54dda"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "1c07afd380f25c076ca0e568be205ede18c875471547133711f04bb2ffc9936c7c97708605cca18c9a98fc94b072caea"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "f17eeff5983e9e0562c90b8b3051b2dbee885818adb104ba8700a399f90a1a3c85a766686dafa06122cd6f8979561ea9"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "c41833778a14d364e29767d543ac402e93222616bfcc020552f0f037cfc6b02a"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "0dace1456d22070719b6e7322cdfb64b34f36f5c8f271f62026c691b00fe32fba50ac17f61b467160ec2b7cabdeeac77029ded3d7f9b1e08a4a0f709222a5017"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.jboss.logging/jboss-logging@3.4.3.Final?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "http://www.jboss.org"
+        },
+        {
+          "type" : "distribution-intake",
+          "url" : "https://repository.jboss.org/nexus/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://issues.redhat.com/"
+        },
+        {
+          "type" : "mailing-list",
+          "url" : "http://lists.jboss.org/pipermail/jboss-user/"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/jboss-logging/jboss-logging"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.jboss.logging/jboss-logging@3.4.3.Final?type=jar"
+    },
+    {
+      "group" : "net.bytebuddy",
+      "name" : "byte-buddy",
+      "version" : "1.12.13",
+      "description" : "Byte Buddy is a Java library for creating Java classes at run time. This artifact is a build of Byte Buddy with all ASM dependencies repackaged into its own name space.",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "c9149a2f7f9190bbf415efd4cc5aeda0"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "035ffee9c24b1c68b08d9207e1a2d3da1add6166"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "6a688bff5b0da4f4f26a672be6623efef94837f1dd49ef2d1f5f6fe07c06699c"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "3203370c94caf8fea95d881054778d78130a9656ef0576b712b51a5e85d25231cdc805fd616987b77aedb99e7604c1236a335c9531cd2836b745625f02321bc8"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "443ecfdb84d0756094a883c4d900f9b5a62b47f2dcc2ba1edea9a8bc38119ee35e5be79f7fbffd2295ccd5b6adc33c3a"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "4672d5f9c98830c4bc78073e9bd70643f19ec099b78c662af37ea50ce6df718d0d62049313fb0d55135b99552eddba22"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "13fd54f8437d9ddb05d6ce90ef8db313a9bf84fa7409549aa1bc129cac988af4"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "4a3e9b5ca73c089f889a094d6a067a37b8e9907755a80b32aed563d1b8df2c91c07a3be451d13dffe51801d71b7a7403a03895897d8ede9b339d3d9586b25e60"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/net.bytebuddy/byte-buddy@1.12.13?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://bytebuddy.net/byte-buddy"
+        },
+        {
+          "type" : "distribution-intake",
+          "url" : "https://s01.oss.sonatype.org/service/local/staging/deploy/maven2"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/raphw/byte-buddy/issues"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/net.bytebuddy/byte-buddy@1.12.13?type=jar"
+    },
+    {
+      "group" : "antlr",
+      "name" : "antlr",
+      "version" : "2.7.7",
+      "description" : "A framework for constructing recognizers, compilers, and translators from grammatical descriptions containing Java, C#, C++, or Python actions.",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "f8f1352c52a4c6a500b597596501fc64"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "83cd2cd674a217ade95a4bb83a8a14f351f48bd0"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "88fbda4b912596b9f56e8e12e580cc954bacfb51776ecfddd3e18fc1cf56dc4c"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "311c3115f9f6651d1711c52d1739e25a70f25456cacb9a2cdde7627498c30b13d721133cc75b39462ad18812a82472ef1b3b9d64fab5abb0377c12bf82043a74"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "2e811e531ce30a2a905d093a00de596cf04406413b60422db8252b46125cadf07b71459cf6ac6da575ec030a9bf05e57"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "bdf019332ae8714ef6a3904bb42bb08c1fe4feacf5e6137274884b0377d4e5b5f7aa9fe8e1ef5ca9b3e15f12320fdb67"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "babce5c8beb1d5907a7ed6354589e991da7d8d5cbd86c479abfa1e1dfc4d2eb8"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "3a8ce565280a157dd6e08fb68c317a4c28616099c56bc4992c38cf74a10a54a89e18e7c45190ce8511360798a87adc92f432382f9d9bdde0d56664b50044b517"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "BSD-3-Clause"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/antlr/antlr@2.7.7?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "http://www.antlr.org/"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/antlr/antlr@2.7.7?type=jar"
+    },
+    {
+      "publisher" : "JBoss by Red Hat",
+      "group" : "org.jboss",
+      "name" : "jandex",
+      "version" : "2.4.2.Final",
+      "description" : "Parent POM for JBoss projects. Provides default project build configuration.",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "489f7a97d2ed7ae34ea56d01b3566d57"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "1e1c385990b258ff1a24c801e84aebbacf70eb39"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "3f2ce55c7d71e744581488dc5105806aa8084c08e6e916a019bab8f8698994f0"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "635642582701f6ae26df91e39d5bfd9345c4c219da73e71a27f4740a4c0c7970f52cef667bb9cc4dd08c26d9b0447ee003c9e56d5ede68870976356c2fcc4a5c"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "ed9e4cf2b47f0891d5fda2a4a63650f0309a5e05f4b51b208bb0c0759dd1cd713e8db68816666ade0fc2faa855bd98c1"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "66c79624a37e19a65063c3d3c0e4779c18e33c2f558078abe1f05c69b1a85a6aae561f0aee1163c41d5efb4a315a3567"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "b6214feecbcb01f82e7442d614d5ddfb02efb686c0b603def92fdc7545f46412"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "0073443439cbc3897ea98f332c61422e0ffd40309fd93c6683a35f70df8e4828ed9e34025e0368ea55935d66863bdec895560054f1869dafd87f2bfc21f47ebf"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.jboss/jandex@2.4.2.Final?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "http://www.jboss.org/jandex"
+        },
+        {
+          "type" : "distribution-intake",
+          "url" : "https://repository.jboss.org/nexus/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://issues.jboss.org/"
+        },
+        {
+          "type" : "mailing-list",
+          "url" : "http://lists.jboss.org/pipermail/jboss-user/"
+        },
+        {
+          "type" : "vcs",
+          "url" : "http://github.com/jboss/jboss-parent-pom/jandex"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.jboss/jandex@2.4.2.Final?type=jar"
+    },
+    {
+      "publisher" : "fasterxml.com",
+      "group" : "com.fasterxml",
+      "name" : "classmate",
+      "version" : "1.5.1",
+      "description" : "Library for introspecting types with full generic information including resolving of field and method types.",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "e91fcd30ba329fd1b0b6dc5321fd067c"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "3fe0bed568c62df5e89f4f174c101eab25345b6c"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "aab4de3006808c09d25dd4ff4a3611cfb63c95463cfd99e73d2e1680d229a33b"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "7fc4764eb65227f5ba614698a5cf2f9430133f42ec6e2ae53b4c724ee53f258541a0109fe0659e0b9e45729b46c95c00227e696b8d1addcd772c85f877658c9a"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "28b4780b2353ebc08dbc02c9a343527a9062a0455bfb4ab135cb639c03e5dfd9c2250a835c44d5f17d275667c2009694"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "b194ace8f1f49f410286bd859866678b95a1b2c6f73e41f48291eb7438dffea57aaa9b177459038b6997771ce4d1cee1"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "50234c94efed4c816eb77bd2f70b869c9f89ddf8ee73dc25e354f4d0b81b3e1f"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "9886421726066b313a62283a6811b76d904ea1c1e9b7b2d850cb47afa189b03cdef053c8f7f6b79e77f2269c45f8cc2ed75c3389e96594b50987fef311d5a25f"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/com.fasterxml/classmate@1.5.1?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://github.com/FasterXML/java-classmate"
+        },
+        {
+          "type" : "distribution-intake",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/FasterXML/classmate/issues"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/FasterXML/java-classmate"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/com.fasterxml/classmate@1.5.1?type=jar"
+    },
+    {
+      "publisher" : "Hibernate.org",
+      "group" : "org.hibernate.common",
+      "name" : "hibernate-commons-annotations",
+      "version" : "5.1.2.Final",
+      "description" : "Common reflection code used in support of annotation processing",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "2a2490b3eb8e7585a6a899d27d7ed43f"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "e59ffdbc6ad09eeb33507b39ffcf287679a498c8"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "1c7ce712b2679fea0a5441eb02a04144297125b768944819be0765befb996275"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "9ce69f19b2e080071a69a2faa992be70b2c153d94862c306f784d1f91fe66e01139c13a3b4f156ee17bdc58ea9c93b61e2dbdfc43152d43896610251488c6e24"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "4f1652cc7f93556ca615f7a70a63e22004f7e1325b6d38492c5601d9b13f9ee3292b7e8919c1a0ef41de0266ed84b941"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "c39a9a94055696454d0ecc5c9718ca1ca7ea05f3b22eb8991c69f31e976a595b86fcaa37fd030c03c0860610bd7251c4"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "a2dc556200c3503ae769c6efa3634a94ac30f475f60b9fd7e478c8919e326720"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "4c791c5d5c43a3d4907f495966d89bd281d90727e3884d889b07a6e88c0ad3f9a712fabf4f2d73c57412d9eff1946ac48ad5450067ca9f6e83212ab09c18907e"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "LGPL-2.1-only",
+            "url" : "https://opensource.org/licenses/LGPL-2.1"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.hibernate.common/hibernate-commons-annotations@5.1.2.Final?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "http://hibernate.org"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://hibernate.atlassian.net/browse/HCANN"
+        },
+        {
+          "type" : "vcs",
+          "url" : "http://github.com/hibernate/hibernate-commons-annotations"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.hibernate.common/hibernate-commons-annotations@5.1.2.Final?type=jar"
+    },
+    {
+      "publisher" : "Pivotal Software, Inc.",
+      "group" : "org.springframework.data",
+      "name" : "spring-data-jpa",
+      "version" : "2.7.2",
+      "description" : "Spring Data module for JPA repositories.",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "5e92ee78425c9f895993ff68687f6113"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "1b8783e98d4199c8fbcb46765fbfce02f41907fe"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "75a6a455d328728f4985cde9220267633b4e0cf2509f9d7c4aa9aa55c6ca2c89"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "e78a36a1a4574aef52b30da4abe7067a603739544daf8f0ff645d5f79f6442a46162e6cf8ded3794f411ad72a7de9463a1cfea2345178f4676f2715cd2ba28a8"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "770a77e03e3653ab36fd845ba4051f0563f789bb43c54eca201650f2954f5de3ce4aa936ae4b87dd2b3d096906003eb1"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "12a8e2b22615d063f96cd91eebdf25d3d11a668b691a6b522ba651cffe4d9107cc6179f7ca2313198643fd3eacedac77"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "064a4d7dbe7c44f3748e9781a150e2600e8bcbc3ce7a20a942c256359cf6464f"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "b3e3db43c8413bf3c56f359af62a295de9622de9d36dd332fa360fbdc236d19b1fbb80d548fa07624a82f583583b089a57dea16c62c062b1f0c56206c9f00a26"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.springframework.data/spring-data-jpa@2.7.2?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://spring.io/projects/spring-data-jpa"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/spring-projects/spring-data-jpa/issues"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/spring-projects/spring-data-jpa"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.springframework.data/spring-data-jpa@2.7.2?type=jar"
+    },
+    {
+      "publisher" : "Pivotal Software, Inc.",
+      "group" : "org.springframework.data",
+      "name" : "spring-data-commons",
+      "version" : "2.7.2",
+      "description" : "Global parent pom.xml to be used by Spring Data modules",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "e488e8db2bc5e559c79f09572a0797cf"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "9547d1234cb380234066aef60129bb2ddfdc6347"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "dfa59582fc3315bf3e3e4efd73fc4399043e4e18ff07917e31f5269a82bc7bd6"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "74ae2a5d8eedc5004ebb25d041a87a3fd7a754886450ce6cfc1d4f303a10d186ae3dac43f6b697fa846115c7680be797b9f93436164abff7520e0c6f61d7c208"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "a6ed78fea3590fdc89dd9efc36509646899caa87af2a185f80420f251d754b48bfc40ea91684729d210c984394019057"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "5734c976363d397be226aeb61d1a3d9d8de8e8279eb610831caf0badb5c3f011f4b5da610d311e15f3d2bfabb0ae8178"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "7deaecf60788c318a8c90654ff4d46416b2adcdb5647fd0eb96be40ac36e0504"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "d59e2ac3d21b6dfb3646908bc85b97724b027f1ac1426ac5f03704ac423e1d7e3d65a0ac2f50dc6174e67bd6d7b7c7495dd43c0dd7f54ce86b6043581b74d427"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.springframework.data/spring-data-commons@2.7.2?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://www.spring.io/spring-data/spring-data-commons"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/spring-projects/spring-data-build/issues"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/spring-projects/spring-data-build/spring-data-parent/spring-data-commons"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.springframework.data/spring-data-commons@2.7.2?type=jar"
+    },
+    {
+      "publisher" : "Spring IO",
+      "group" : "org.springframework",
+      "name" : "spring-orm",
+      "version" : "5.3.22",
+      "description" : "Spring Object/Relational Mapping",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "f4cef9fe1dcfc5e6b534851f8f2d979b"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "abcefbf4895a3daf263cf385cc66e924db92d254"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "8ac282390de9cf94996326297d9aefdfd02930a8d115fd62790ade28f05515b1"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "24d731590ca3867e58bd65a224f6138c465ff397978bd1b2bf212a0dafe6167641882f05b0fd236b733912b8d0f977a73989eed86bd4218ecd9a5b5ecb099235"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "52776a942281ccca53c5e24e37c3b2e2a85eedf5723ca9a0bb602de5d77d6e7defaa6fe77b32aef4e743738bdd54b0b8"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "f8906009fb9242fa53209bf3d5a59ea3d84570318817e0de740ec59ca600274ded376cb440fa379cc813ad5b95469a89"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "cf598b0e81728122d9087611f504b4d119c0db086a5c6e09eadef7d46a575c73"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "82c6c4dd4fd5e1901b53a7bfe929e13fadb2088b837f2b925b281d61cac0687b844e89e2b3b500fe67c4d962f4fef4b3422122ebd0125a5ec87ca12d61428777"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.springframework/spring-orm@5.3.22?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://github.com/spring-projects/spring-framework"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/spring-projects/spring-framework/issues"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/spring-projects/spring-framework"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.springframework/spring-orm@5.3.22?type=jar"
+    },
+    {
+      "publisher" : "Spring IO",
+      "group" : "org.springframework",
+      "name" : "spring-tx",
+      "version" : "5.3.22",
+      "description" : "Spring Transaction",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "84646a02ee3a0ed0b20d7ce9e6ecbd94"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "d0b3812ab20987a13f3a9ae7b4c54f619e034692"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "7d93ff5f35374e5a0c5361e42c6209d660ea81da31fe580bedfe8a2067ffce8b"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "ec2e135a80924a60c8c0970a60097eaec76ba8cee3e1afcd77bc6416a08be5d990364b367bfedde9bdfddb496f6775e1768891a6adc408ad109a27825a5689c9"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "f5a01534511b9852e835622fc9ee303e19e983cc4c5dbdefb58a6e920b0bf17e6ca98c16a3abf9fc0dafc1eec455d615"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "6352440b579d3bcacfc4377b089eac5559c3c5f08f79a7afe066aed2fc758f1a3be18ff82a823746ec2e47594124d6c1"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "f29047b7bce614add3bcfd87b8fc5c1c08ed02afdf4091151773917ba59837c0"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "1fc82feb5b54311ff33cf7b134691fecf7e796a9abd12984a4ab2638a70b37c398c4ce3ce7bcd1b36021ecd0ac625c994ba011d578935436e0a7ebc593c54219"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.springframework/spring-tx@5.3.22?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://github.com/spring-projects/spring-framework"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/spring-projects/spring-framework/issues"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/spring-projects/spring-framework"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.springframework/spring-tx@5.3.22?type=jar"
+    },
+    {
+      "publisher" : "Spring IO",
+      "group" : "org.springframework",
+      "name" : "spring-aspects",
+      "version" : "5.3.22",
+      "description" : "Spring Aspects",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "7d27212a6c8652bb56705e9c59cfe1b0"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "1fdd8ac7f557ba12bb59086edfe3a9cdf6d918bf"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "576489cc76ea4d058bf07227f6a6eedfc87e6045614ffa9e9f0b0d8ba3f48003"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "abe4f62ca988d3ee8fa0eea582552ad32fff03e5a0d55aee1c425bd1b24ecf1dde4c313521da33dff3e12b5466600e054ebdeed4f94b8c3e1667290745d186c7"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "7ab627ce19a96dfcfa0153659840e968d1343547b8cb81b849921f20e0c4d6f2ddbbf8b6c22e30089caba38e5e2f5b94"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "7f4e5c6e0ca60bd2186fb9d534351b6384cfe482ffb243ff0da24583c8b5b545c2b9f625819bb89c6412a29ca68486b1"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "50292ba3cf29ab128bf6cdea912aba2210b6b1ebaf7e2c28b0a6dbd2f81e6c08"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "e0e127a8d773992262ec1a7e41e79577c7d4f17a5c8099ae0aca194aa7f7572add4c0164a2e12a4f0ad3496bff5d23582029bf7c00ea7645a15c2bf5456120a0"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.springframework/spring-aspects@5.3.22?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://github.com/spring-projects/spring-framework"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/spring-projects/spring-framework/issues"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/spring-projects/spring-framework"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.springframework/spring-aspects@5.3.22?type=jar"
+    },
+    {
+      "publisher" : "Pivotal Software, Inc.",
+      "group" : "org.springframework.boot",
+      "name" : "spring-boot-starter-web",
+      "version" : "2.7.3",
+      "description" : "Starter for building web, including RESTful, applications using Spring MVC. Uses Tomcat as the default embedded container",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "b0202373d8b5c38481b401c4a48fb00a"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "9e36c7517c4f872b69d0665e1dd46bd6d83c43b7"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "356105ca8dea2264207f7ca30c2ad252ae0a989e61a2c8cc8f64b2cbe4e61fbe"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "e1df0ad21b1aca033d3e666ce3d544e30f8affaa80e294cc29048146947be73a68b7b8be89202525c6d4ebc0106318a6424780e2781e65dc95adc23eacb10509"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "c702cac278accc3977ef8599140e8c8b3c8f542d5172f2eb3b94bf35487876dc3bc6621e64f35ec8ddde8361936602ac"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "32174b20ae8cad4c1613fea81a752f58ee23b1277bc1c2a66747dfc19a403f453554caec045a5d73424cf3157ff661a8"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "c41986b49469994c7c54f2112398c81bd72d17926999b1e56a28d544334e6490"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "a9e3f8dbb44152bda4ba3ce2f618d05374ec350dd15e878abbb9f25007821b503dadb69eaa07d2dfdcebd10b9e5f7af3b7a0828c6a35dae8bf92105732690a7e"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.springframework.boot/spring-boot-starter-web@2.7.3?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://spring.io/projects/spring-boot"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/spring-projects/spring-boot/issues"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/spring-projects/spring-boot"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.springframework.boot/spring-boot-starter-web@2.7.3?type=jar"
+    },
+    {
+      "publisher" : "Pivotal Software, Inc.",
+      "group" : "org.springframework.boot",
+      "name" : "spring-boot-starter-json",
+      "version" : "2.7.3",
+      "description" : "Starter for reading and writing json",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "b115a29addf8568e87ca7dea7ca8de51"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "38c88404d68926aaf6c0914199e8c5e766946de2"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "b41db71097823e28aafd7fa45eb38c546bd32ac86614cffaf54b1b93bf955952"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "7fb627d880ffd920671f0d7b9bfc6b0edee0e505c43dbd0dd114e05d209b853bcd5e6b2578b9d48d84d9f3d9b026d1d3fccf5ebc070dc8f388e092f988068985"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "346e4a54289a3b8513581072b6ec6282b02736b689f975e8aa175b037124a7aceacad93bbc40f153114c9627870492df"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "0c6b38be19ff152f273d375ac8d3ce07609c15ee15352440cc3065588671206a028a1ac67b7d38ce0f3010532c02aa0f"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "1480b8f0cce248186dc9aa6e6b293b85d287f468c0a17ea7451619814e7993ad"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "92b12ef5057914371e5857ee62851f54af0a15084a47c448606a7bb58c12975f55338eb5c689f79cc666b8c77b16ab5f883a6f1a399338f2364901508bb870a5"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.springframework.boot/spring-boot-starter-json@2.7.3?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://spring.io/projects/spring-boot"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/spring-projects/spring-boot/issues"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/spring-projects/spring-boot"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.springframework.boot/spring-boot-starter-json@2.7.3?type=jar"
+    },
+    {
+      "publisher" : "FasterXML",
+      "group" : "com.fasterxml.jackson.datatype",
+      "name" : "jackson-datatype-jdk8",
+      "version" : "2.13.3",
+      "description" : "Add-on module for Jackson (http://jackson.codehaus.org) to support JDK 8 data types.",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "8dfa569e8efca9df24887bad202520fa"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "d4884595d5aab5babdb00ddbd693b8fd36b5ec3c"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "1ece4fa7591be315b38aa986ded0ebc8dafcabdc0260f7819e663543a401bfdb"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "0d2a20ea9f30330e65feff7d9873faddeaec443d51b5b5689dcbd6abba6f0ce5b86ce7777b95899e33cc88529351043e414fe53aaf8a65081ef9adbb6b2ec2be"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "3a42b22faf4c401ce4f7b29514a1655907a81b89b3fb60f0e4ab78c80c335baa5586b7e9bf25c3bf33af4eb002531875"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "1a9f005078c0eeaef0204e7dd98f77b1adb95006c8b21438453d203cc7765a89ca08a6633ffee652532d4d17b9f0d1cf"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "f4298649801a97fcb84538ed20096683945176a39675b5d78ec78354d198e42d"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "3b2d112645d3d1c2b74f3519754a9e672c18b3e729870891267c4c76c92d01814bbf04a89a29744fa5e712f9502375f12515660f833cf20b3e3e7f8e3ffc5ae6"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/com.fasterxml.jackson.datatype/jackson-datatype-jdk8@2.13.3?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://github.com/FasterXML/jackson-modules-java8/jackson-datatype-jdk8"
+        },
+        {
+          "type" : "distribution-intake",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/FasterXML/jackson-modules-java8/issues"
+        },
+        {
+          "type" : "vcs",
+          "url" : "http://github.com/FasterXML/jackson-modules-java8/jackson-datatype-jdk8"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/com.fasterxml.jackson.datatype/jackson-datatype-jdk8@2.13.3?type=jar"
+    },
+    {
+      "publisher" : "FasterXML",
+      "group" : "com.fasterxml.jackson.module",
+      "name" : "jackson-module-parameter-names",
+      "version" : "2.13.3",
+      "description" : "Add-on module for Jackson (http://jackson.codehaus.org) to support introspection of method/constructor parameter names, without having to add explicit property name annotation.",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "b6e20ffb82b7f26f19146f5cd5493738"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "f71c4ecc1a403787c963f68bc619b78ce1d2687b"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "6c4c82d16460f41982311efbdd6285a5c898beceacd8c913ef9e3a1ed1a1f4e0"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "547bd36751c50a261ec2f7210caefab38cbfd042af3aedbe016de15863bb19bfa5590d0d213c7df362330e1ecf810b5e5840ddce04c3f53a0f081a01d5dad8c1"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "5f873a0fc1bba649494e58e9d06f1889d17f9d3a1434ba74d436656d2194c255b2f599cf2eb2d8159a59adb2440b8677"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "c404fb31d92431be6e94a2361811df40cbccb3df5a347d86b165a938c9be926c54edd4fe02c45867fda1e14088c668ee"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "7e547be835120f96e6c413010c11142d026e0c7bb80a3ee203f2bd8738611d83"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "2248c1b110f9d87f7077f2435e87989bd67b620c872cebd2046f014274c023131132bbde0cd635ab53bfc295c0f35905aacfe8f1eaca3e22f947db489bd6f18f"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/com.fasterxml.jackson.module/jackson-module-parameter-names@2.13.3?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://github.com/FasterXML/jackson-modules-java8/jackson-module-parameter-names"
+        },
+        {
+          "type" : "distribution-intake",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/FasterXML/jackson-modules-java8/issues"
+        },
+        {
+          "type" : "vcs",
+          "url" : "http://github.com/FasterXML/jackson-modules-java8/jackson-module-parameter-names"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/com.fasterxml.jackson.module/jackson-module-parameter-names@2.13.3?type=jar"
+    },
+    {
+      "publisher" : "Pivotal Software, Inc.",
+      "group" : "org.springframework.boot",
+      "name" : "spring-boot-starter-tomcat",
+      "version" : "2.7.3",
+      "description" : "Starter for using Tomcat as the embedded servlet container. Default servlet container starter used by spring-boot-starter-web",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "903033ef3f3622647594bf95e4715722"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "7a5998baaa05d5e7a9af7194a21f2ac3512ba7a0"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "d9696b94a38f237a58dee2b2d9620e2fb12ce4e73e4d23fbcfce12607885c528"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "416f7bd6b66e880b13f745d883995eec6f7a5be8110746f12ba1b3f3ddc5c2a51eae8fe3bee930be84a77b9b9563195a8f5f66de6c4158803bc9c80509d38621"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "5b687ab81363e64acbb36be93c3b4ed285221be769c5d3f9d98ccbea2fe8d571e104dfaa77712866b7a3d8b66f7774be"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "6250e2b44d735f02d749320bd80bbfd22cf2bf01b9d3f9d6f7f3367123834f40206d05fc963c22a0bd53fb1efb281ae2"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "61171bd9a499158446229338cb40dd527f5bf3e77c0cde5df867a7c6275e1bbb"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "1f0194a600eb4d8b3e833dbe278c26907da540cf83a161253477d3bc322ba89a65b29f38074db352f08721d6213b35d63af1af8b75661ee0e2710fa3c7d73462"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.springframework.boot/spring-boot-starter-tomcat@2.7.3?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://spring.io/projects/spring-boot"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/spring-projects/spring-boot/issues"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/spring-projects/spring-boot"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.springframework.boot/spring-boot-starter-tomcat@2.7.3?type=jar"
+    },
+    {
+      "group" : "org.apache.tomcat.embed",
+      "name" : "tomcat-embed-core",
+      "version" : "9.0.65",
+      "description" : "Core Tomcat implementation",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "67ccecf5fc96bd4c2b20440da1597ee1"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "a24c5f379b2ec343a167a83332b75c37f26b2ae7"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "b4755695783b3ad01e8ba15a4391e626bdfdff567a01de2079f12bb3421b347d"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "be9910109ec88e4154f1c9d28059a3d2e8ae10ff308f34cea56c660c4c45a6bb8a1b3cc299db9f09ac6874282969091fdabaab9da67ce0d1702c621ea01968b2"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "cc234ac5fd05c2173b8b4ee7bb8ebe17d277f4ebb4da56fb7d9806e4d17bc722b4b580d062e395837a72ef8651ba8a6b"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "425e4a2aa7837488e221555a8934cf26f2e3e7a4cb916cb765e4d9868ac15663fe4d65867f05a170a5c0498c9cc43ef6"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "40b765d776b5918e001da3b94c5affa12e0d41f4d591e781b10f85bd679430d2"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "8271df9e531c678ae9da87dbf1bc16a9c6fc07ebc5595fee35a9826c4ad17f0323077317369db7f58756c5b5450e14dfa631afa54b323ab5eb60f5d0557d3b20"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.apache.tomcat.embed/tomcat-embed-core@9.0.65?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://tomcat.apache.org/"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.apache.tomcat.embed/tomcat-embed-core@9.0.65?type=jar"
+    },
+    {
+      "group" : "org.apache.tomcat.embed",
+      "name" : "tomcat-embed-websocket",
+      "version" : "9.0.65",
+      "description" : "Core Tomcat implementation",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "0e951a3fecce7dfdb63ea0793f2f5b32"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "bd70dfeb39cc83c6934be24fa377b21e541dbe76"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "a5c71902c4d26153f1256491362dc94e6598e70e3ba06f19ee02b1dfcd392470"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "f6c5d3f28b1d6d9b9ac7937e61ecbdb12ee779614fa049b8659786331677c5767d8ced9d93b1659a88ac00790c6297e029fd73e3aa96fb5e6c95cbde23de5e26"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "f2514fb2b7c335ee1134bbc506670be729428d0bd241507fa0d665613f52a65186abe9b7e9c91b517627d34ab7abc365"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "24427747f5453252838938bc4a9c7ad6547079f62d5d6f42bb69fc8b72f42caae68489785e169276072561d6e48a8bdf"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "459da6d372e1d9f8ca4e9cf33bc6ca1f6cdc95c6d1171fb0838e0b8a4e2df2ab"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "55b18bfe221ba157635eb43bb25f129faa32ba98886d384a9e208aff15a8e124013050cd7ad6d4d1dbc3a79ed6716404d7e483ad7bdeb8dab898eef612ff4b46"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.apache.tomcat.embed/tomcat-embed-websocket@9.0.65?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://tomcat.apache.org/"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.apache.tomcat.embed/tomcat-embed-websocket@9.0.65?type=jar"
+    },
+    {
+      "publisher" : "Spring IO",
+      "group" : "org.springframework",
+      "name" : "spring-web",
+      "version" : "5.3.22",
+      "description" : "Spring Web",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "6096e895ba3cd63edbf3aa2ee21b84a9"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "fdab9b8d8df2e6a8fb90f2481c361bcf2c129567"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "d201925a5f619a5f51107ed07043a847c645773165c954bc34fa5983fa043f1f"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "c56a00c97d3b5c432cea48d3e794eb0d3999d6c6439d70b13365db623c41c7ab9ce065bb58388bd38572a6ba54bbf357793e520de0a07dcb42967e4e167e5b4c"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "d47ed3e83dea9006de8940cae1b440597a7cd869532e057f19e75e4bdca5653f10b9de0213665bdeb6286cac64a7c852"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "ed323b4a5de35d92ed413d86a4eded4f133dbff4da548e2e34e98f6abd56c53141887c50ed024c0f45b5e48d7937621a"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "1b45711721eec8e6a3ba4b208652837db29ffa95eca667b94c9e07a48694607c"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "f25311622862d97104aa8839d369bdf9066890e514412ea03865674559a4e1081a652606c786d44a4cd4645d5fba4022d3f10afdddc4607164cfd579165c303a"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.springframework/spring-web@5.3.22?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://github.com/spring-projects/spring-framework"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/spring-projects/spring-framework/issues"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/spring-projects/spring-framework"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.springframework/spring-web@5.3.22?type=jar"
+    },
+    {
+      "publisher" : "Spring IO",
+      "group" : "org.springframework",
+      "name" : "spring-webmvc",
+      "version" : "5.3.22",
+      "description" : "Spring Web MVC",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "511ed52d5c8ffeedd6529bebcf9d86e8"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "519d86b7ac9b8b6bb54739eb4eb73dc13a263b28"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "243192abc127cd3544a7077c61575dd61b2fcd86a77a63c63cf119fc562fd961"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "3a3c4b0a5a01bad22bca5dc5239c01b0c39e9469600ffee268b28cdebe8d330f2c9d9f493914dffb66ef1802d88e71c3b4a1073315e899c3e37f267c1f265eb0"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "c8baa3430c45ccd16463b88f3062fb55a5fa9afdf26b1b4bdabb719ff928ed8150fac86e7cd06e98c37a353c2d4fcdf2"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "58d19fef8d4597347b4fabd55bdb26cc8194bc4257f455546039d4f6bda0ae37b6acace7fb2b9f4ba2b38d279ed6e2e3"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "caa43082d30e2d69dd549f72851ed7509ef8e1453ab48ba4702c095b137714d5"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "b50f1a99318c786aa63bd0be6c51cefdac57cb3b42768f96d811c7b426915c6bb6d51f0c590b4742d2b915abd972210f05dc5be10536b89f094e543f3b898caa"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.springframework/spring-webmvc@5.3.22?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://github.com/spring-projects/spring-framework"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/spring-projects/spring-framework/issues"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/spring-projects/spring-framework"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.springframework/spring-webmvc@5.3.22?type=jar"
+    },
+    {
+      "publisher" : "Spring IO",
+      "group" : "org.springframework",
+      "name" : "spring-expression",
+      "version" : "5.3.22",
+      "description" : "Spring Expression Language (SpEL)",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "1648040f13200e725ec6393c6ffa1f9c"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "c056f9e9994b18c95deead695f9471952d1f21d1"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "c4088592b55c8c29888a3fefdd1e0ba8192b4216c3be963ed66a5c6b82b53428"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "7e1502884e9343ac70b6cdb678454444f5ecf33d80715f90da1e5cd196f5bac5d5603c671bb9479986e36185782fb5e7b1bcb983a3e8939f1e57122e8891134f"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "ecf120bc08b15c99c836a3bffd75c29f1ea913fc8334d7344814c308a61d04eb304be6c5321cb7ba684c6b3adc804cb0"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "653e49cfba9dc9497c542cdc4dc2d10cae10f4b3f89dfa2e08c64eff1e15e66ecc7ec208ecc4c41bf77b95d3d784487c"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "ac0b0e4ef5525c4c61556f8dae2956210fcec8e3bd104bcef30716ce5efcde8f"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "023830cabbacdf063ce2c2e4f67ef7f932ba5e147fb50d81720482729731530082e4c699a4fb001c9d8c53c69e74a61102460865dbbbe6211b2665f05c97afd5"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.springframework/spring-expression@5.3.22?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://github.com/spring-projects/spring-framework"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/spring-projects/spring-framework/issues"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/spring-projects/spring-framework"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.springframework/spring-expression@5.3.22?type=jar"
+    },
+    {
+      "publisher" : "Pivotal Software, Inc.",
+      "group" : "org.springframework.boot",
+      "name" : "spring-boot-starter-validation",
+      "version" : "2.7.3",
+      "description" : "Starter for using Java Bean Validation with Hibernate Validator",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "f3212373cf22f24f4bbe8fb0ed919ea6"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "c2e59c8d4df01dfecbdeac96693944ffcb2527ae"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "1d6ba58e036c78911c598e84f67260013fb2affbea2fb426dc51a49626006699"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "383bd99a66feee62a84095e0e093cc233dd2041f0b2cfd8c78f21baf7d719409f8000dfe021b9ff515579d695633b598da5ab48d4bb2e949cba7391e6c2825c8"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "70446098f0ee24cd9d34f9eda0732639b18dee225af8018bc8b160e47f01770a2bfa6077856248030bdf858c62a3cd48"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "f4bf7ccdbaa22e694d174eefc2b12f4a0898d4bcc077e68f7afc4299f5a8993f8cc4737e78bf4cd64a2e9bcd0b184f64"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "bf1eec55bb6ab5e127db888db8920314d1dd59aca9edab1d9f01b727205b9334"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "627babbd8c682d44f7ffd677a0981d052e534ba1fb1ed77bfaa5a38d150e24ceb6b1633c1506c86962fd43ab6b8bdc3109b2d4b1780920f56a7ff4e4f8e00c6e"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.springframework.boot/spring-boot-starter-validation@2.7.3?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://spring.io/projects/spring-boot"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/spring-projects/spring-boot/issues"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/spring-projects/spring-boot"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.springframework.boot/spring-boot-starter-validation@2.7.3?type=jar"
+    },
+    {
+      "group" : "org.apache.tomcat.embed",
+      "name" : "tomcat-embed-el",
+      "version" : "9.0.65",
+      "description" : "Core Tomcat implementation",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "6510b8b32f9226e27d75aaddd802eee5"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "d278157387e59a5f9b48091dcada22b7c74aed00"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "b90a1a2a257103e54f39195ced80fa70d7ffe45813e1e226e0242c29c7c82879"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "bff34ae27291027cde7ff95e769e806f6748655a9e617cba64453d0e9b04e6b49c0abb87fcfb68116bead7c4598ac717a43fa024b0d62721a8c48caa88e37031"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "d66d61d3d0b64f0d5e2e187771cef478becd0b4a85fdbed6a2780b95031b7291aea8060cf6076447049a51d93b9de685"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "574d80c56e436dbe078fe3ac614709ddef827e91809e775045232bea4e26155968cf13a73b018a3929646d969494c531"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "32e2cdbe6ebb6499efac3747dbf4dfdc010f12f8477e0ebd44b0f1c141e21fc9"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "585a4aadf5ac27fb438801c9ca83cdc1860ed102eabddfdaea0913c8f25a4c50d1d86fa1e95242c2010d468deb1ee899b6a2b718ec4cf44a5e90b8de640a8937"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.apache.tomcat.embed/tomcat-embed-el@9.0.65?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://tomcat.apache.org/"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.apache.tomcat.embed/tomcat-embed-el@9.0.65?type=jar"
+    },
+    {
+      "group" : "org.hibernate.validator",
+      "name" : "hibernate-validator",
+      "version" : "6.2.4.Final",
+      "description" : "Hibernate's Jakarta Bean Validation reference implementation.",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "363092a69966c14c7d32f6c8db6369e8"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "5acf6de251d9e29102a1f30657cc3151ce3c8aeb"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "6015910ff12ea61291f277bb6ed80d26b3eae0d45d4e6bc482ad492a2a9ce8bb"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "08d4b7f608ca57d47a3eac87dc703b7315dee770e70095805bc78f04a0e773b0a4a262a170f3d2fd6083a139828bd4ceb2766cc621cf062bec57f2a4cc4ac37b"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "15c902d115ec4856813443fd1451b259357cd104933cfb976b8c8d391bdf21b46b56acb3de259b91073cd63e214dff1e"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "a72561de0ecc80d95b10e8af66a0c5a8562f97cdc7ac3d898c1b20b9da68bb0839552b19ee8ade86fe4f9bc3aea3e9c1"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "2313d7d1742af95bf00b8d4e521dcfcfea1e7510220c9acd46c091c208959a19"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "3fce0cd1a22d383fe498308f1e30e34ae1239b11fddcf1fa7a9dff8f27eb33a5cac4993b3c3ccebaa656302a2cc20722250aa88eadf35f4fae309dc59c4b92ca"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0",
+            "url" : "https://www.apache.org/licenses/LICENSE-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.hibernate.validator/hibernate-validator@6.2.4.Final?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "http://hibernate.org/validator/hibernate-validator"
+        },
+        {
+          "type" : "build-system",
+          "url" : "http://ci.hibernate.org/view/Validator/"
+        },
+        {
+          "type" : "distribution-intake",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://hibernate.atlassian.net/projects/HV/summary"
+        },
+        {
+          "type" : "vcs",
+          "url" : "http://github.com/hibernate/hibernate-validator/hibernate-validator"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.hibernate.validator/hibernate-validator@6.2.4.Final?type=jar"
+    },
+    {
+      "publisher" : "Eclipse Foundation",
+      "group" : "jakarta.validation",
+      "name" : "jakarta.validation-api",
+      "version" : "2.0.2",
+      "description" : "Jakarta Bean Validation API",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "77501d529c1928c9bac2500cc9f93fb0"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "5eacc6522521f7eacb081f95cee1e231648461e7"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "b42d42428f3d922c892a909fa043287d577c0c5b165ad9b7d568cebf87fc9ea4"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "3ca8556b80ca809b3a43fac31469702bbad62a00e63b11a304dad1e372d9f6c128357463a4c70c423055941c7e2e417f87a9474a204d189c8e4b62f42047c8eb"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "6ae3963fd6a5e83b068a8344b88f6bfbd26d29cee64193025bc5e98195678e49826463da27a7a1c15cd83b2149d57a94"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "55a570386718064b422f9ebc0c0c07f0b37259e44a14c9a16c20e945402339b1d01b7d6969ef40d6b5baf5bce3e1161d"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "1ff48fdabab86a398b25e491e6ba4fd9b62d597314202628a3cfedf723c17f21"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "c23bb0b43fb0c39d4c9d2cce0cd38334fa7c253130f0bda3007d9f7d2dd451c0896ff4265ee2cc35024fad282f9ccaa398c19874775d9cabbb786843fae155d7"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0",
+            "url" : "https://www.apache.org/licenses/LICENSE-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/jakarta.validation/jakarta.validation-api@2.0.2?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://beanvalidation.org"
+        },
+        {
+          "type" : "distribution-intake",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://hibernate.atlassian.net/projects/BVAL/"
+        },
+        {
+          "type" : "mailing-list",
+          "url" : "https://dev.eclipse.org/mhonarc/lists/jakarta.ee-community/"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/eclipse-ee4j/beanvalidation-api"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/jakarta.validation/jakarta.validation-api@2.0.2?type=jar"
+    },
+    {
+      "publisher" : "Pivotal Software, Inc.",
+      "group" : "org.springframework.boot",
+      "name" : "spring-boot-starter-thymeleaf",
+      "version" : "2.7.3",
+      "description" : "Starter for building MVC web applications using Thymeleaf views",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "59e3d0a58b776ccf776ea14303553bfa"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "3dc30e21fe12e5ebc6beef56d1cb5d59fbc0b285"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "164cdab88cb340fd37dafefeb449ffa2df495c53fd41385cde5ba9695b51c7cf"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "f314714f733ca47935ccbbd68c141d8780ad0d452d335815738907e434813350730a459d688ee1d86d6f21b645bdad17b3135421d9bb8f47e4641f86f80f470f"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "da3511ceef4e2ea23e63506d2fdd2705b55e4ecd8ec1c72e72dfb9f00e2ef4cd480f4065c5e41078fc2917ced619975d"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "b5a21736bde6b2625972f27a50db405de292c1ef589534a53e48300a491f4849b4e4da5262e236a2905a7dceaf63ad52"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "87e1f9509fbb71a115d19958728c389bef9d152ea83c4a0c7ea7b459a290f753"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "99904943f6eac9507fcf9b983806df1648a9c39a6993ef93dc519db1dac27c690c05304a2aa3fa99bb25be79f06980dd2caa9843fa71d1c84e74adf2ec0aeb3c"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.springframework.boot/spring-boot-starter-thymeleaf@2.7.3?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://spring.io/projects/spring-boot"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/spring-projects/spring-boot/issues"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/spring-projects/spring-boot"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.springframework.boot/spring-boot-starter-thymeleaf@2.7.3?type=jar"
+    },
+    {
+      "publisher" : "The THYMELEAF team",
+      "group" : "org.thymeleaf",
+      "name" : "thymeleaf-spring5",
+      "version" : "3.0.15.RELEASE",
+      "description" : "Modern server-side Java template engine for both web and standalone environments",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "ebfbdb4cd7ce2dd399765b874ed4fe9c"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "7170e1bcd1588d38c139f7048ebcc262676441c3"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "d254da927435a517cfa1a5aed5b27b74818418981ef3b816e8da89e4390b52d5"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "4e85b7285e754c11b582ae419544c92a6209be306cc69d3863d1e3f14a50a2916d53744668f86d4a1eb8a646985c0e98bc8cb3ccf722e865ac0a44b25142ae8d"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "b75286eddfda06304ca2210a04cf6008549f80aa0a135deb47c3b0abdae6e02e67c82067995e85052a1d1f00413e4f7f"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "5bf280ac656a964f7d49ae1b99b32090f6ec579cb68cd3d5508dbedcf9f2f18a435b3683d964c3147bee7f75da73b2ee"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "76cb0309c4d1db3f65ae9a525396d93bd32063dfca1417c60337f195179fde8f"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "6e5546c955eef219fb0dcae720b797937e38fec097ea3d0607594613f5ab6866ddec8c0c37a4192a3ef5b7642e7d5e79b85058298a1b0397576233e055cf5ab2"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.thymeleaf/thymeleaf-spring5@3.0.15.RELEASE?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "http://www.thymeleaf.org"
+        },
+        {
+          "type" : "distribution-intake",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2"
+        },
+        {
+          "type" : "vcs",
+          "url" : "scm:git:git@github.com:thymeleaf/thymeleaf-spring.git"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.thymeleaf/thymeleaf-spring5@3.0.15.RELEASE?type=jar"
+    },
+    {
+      "publisher" : "The THYMELEAF team",
+      "group" : "org.thymeleaf",
+      "name" : "thymeleaf",
+      "version" : "3.0.15.RELEASE",
+      "description" : "Modern server-side Java template engine for both web and standalone environments",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "60c7ebe364a6b704ddf0348476a438ea"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "13e3296a03d8a597b734d832ed8656139bf9cdd8"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "9ea400b29d938eec670684eaa706a4fc11cd6c6ba58fd39b8ea9e13cb0177d75"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "e88a93caff7a153c26bc03c596a55b174e9eb5f10ce79c5293dec6f7c7f910150c0f2e7e523c79395a5eb4290ba5705cd378ea24cb010352fa4fc8572b1fa751"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "a29b4451a3e6453acbe61f49dc0c1f02a3795d3d6f0115df6e4300697e6f18ee3601260dbb3671e04adcf09f8e2297fb"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "4e1b81af85aa55fb5181cd3f263dd5e7ecc9dff65ed7b1321027c687de68f6aac1c3af21a86b38a8d3d5eb22d618a2ea"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "b34a4ec47482923cdec326d10c76c89a17b55041b9d30ad98b6273f428155419"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "73574c4cb7aae72294d192b9977ab1cbd080f7891d2349b7d45b6a5a590168ae438c966a8cd21880b361dcccffdb3f7c483830f70572b0008307f2e6ae53b7d8"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.thymeleaf/thymeleaf@3.0.15.RELEASE?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "http://www.thymeleaf.org"
+        },
+        {
+          "type" : "distribution-intake",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2"
+        },
+        {
+          "type" : "vcs",
+          "url" : "scm:git:git@github.com:thymeleaf/thymeleaf.git"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.thymeleaf/thymeleaf@3.0.15.RELEASE?type=jar"
+    },
+    {
+      "publisher" : "The ATTOPARSER team",
+      "group" : "org.attoparser",
+      "name" : "attoparser",
+      "version" : "2.0.5.RELEASE",
+      "description" : "Powerful, fast and easy to use HTML and XML parser for Java",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "546b814a33d40124427225d6d1df8fd2"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "a93ad36df9560de3a5312c1d14f69d938099fa64"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "d4015d56147f696ed0a90078675bc940529f907e7b2dfc1fad754e8033da8796"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "91b2eaadab67420252e47e52b4460ec13bb8c38a3a9b89a924974a4e2e411f0537a758e924800e4355b83aae5db6925f7e002fb5e0200735c69910d56b216524"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "34555574940d91fea7d83b57f82479091789f113d75813225fe1bd4040f4c98bc259d0fd4544f44181b462bca1554b50"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "99045ffa7ccb7bdce7f0186239b6d6b8bb205c07051c509fe2232d84ce5830f6c392266bc614d87f864e8910b0a6f186"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "6c7ed8d6ffb74f247dab1582f1f03de6adf28246c6957292a5cdc3edbd153b24"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "41e8040d0dcf7adc5ebd3c2bfa04026d8b404f23d25982eb50c885fc7152e3f48f68aa7b095f0b92e985cafee517b789deab9891c83aaeda090b42056bdfdb69"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.attoparser/attoparser@2.0.5.RELEASE?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "http://www.attoparser.org"
+        },
+        {
+          "type" : "distribution-intake",
+          "url" : "http://oss.sonatype.org/service/local/staging/deploy/maven2"
+        },
+        {
+          "type" : "vcs",
+          "url" : "scm:git:git@github.com:attoparser/attoparser.git"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.attoparser/attoparser@2.0.5.RELEASE?type=jar"
+    },
+    {
+      "publisher" : "The UNBESCAPE team",
+      "group" : "org.unbescape",
+      "name" : "unbescape",
+      "version" : "1.1.6.RELEASE",
+      "description" : "Advanced yet easy-to-use escape/unescape library for Java",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "d95ed94e1624e307a1958ee105ccbf39"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "7b90360afb2b860e09e8347112800d12c12b2a13"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "597cf87d5b1a4f385b9d1cec974b7b483abb3ee85fc5b3f8b62af8e4bec95c2c"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "6918e9579b06721942fdcd91e401f5b996fb4eac13056dbafdf594661f355a34874eb5266784bc2c4f82df9fdd9e219d71a96f52945a354f01665f85f8166bb3"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "1b808b67c784b69afea64364ba4c0d433c7f042c512f5c18f07d5388fe7ac4741913f696424bd8fbde147383cfb3d8f9"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "6525bd20a12ff43a0089c0d59369574ae6c01e2b4b1aacf466847d4433ae403db08404a9b59be397c3034f972bcd6b06"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "a190c9bedccff959d08db12fe7080437fb4e98f05516b39d6540be718e151cc6"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "5d7b5edc0c2a0d47c9625936c14b4122330b96cdf54260fe2a6468289c2f4cbc4ee19770c1144acfa702f2f058a81544b4aea9258fe0e15166a1a331736d7b77"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.unbescape/unbescape@1.1.6.RELEASE?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "http://www.unbescape.org"
+        },
+        {
+          "type" : "distribution-intake",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2"
+        },
+        {
+          "type" : "vcs",
+          "url" : "scm:git:git@github.com:unbescape/unbescape.git"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.unbescape/unbescape@1.1.6.RELEASE?type=jar"
+    },
+    {
+      "publisher" : "The THYMELEAF team",
+      "group" : "org.thymeleaf.extras",
+      "name" : "thymeleaf-extras-java8time",
+      "version" : "3.0.4.RELEASE",
+      "description" : "Modern server-side Java template engine for both web and standalone environments",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "01420fcda7481663f967836c440f9bc5"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "36e7175ddce36c486fff4578b5af7bb32f54f5df"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "c07690c764329afd148a4134980d636911390a3fda45f6c6ae46517e4b4444d3"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "e5e35400eb6ed593e20b9718748eb9568b2af7e3e1141c0e0582b82f3b4dfb8d40991b988806ed9b8b3cf1e7f11dd7106ad524fdf7925f7b1836f1be183d4ee5"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "21930e0f55834e8636b98fe10caf775452bd5251560ef2110e78ae2e0a5b7f5a3378677189d34e01e4c58f5fc04841af"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "2f5166979a71b75b44831035b22443d7bef7ad7d6825e3f163841a082f1bc4631ba58e81aac2833f4d35d74cc4a2defb"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "614bbb1c04b2d3c51a10e9d49c23fb00fcb6652e0fbdedb0585a5bd4b923ee18"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "e4738babfee412ed3ea21ac735155f0880d6f20879f84f65e6388c5ef8a2fc83774f4fcedb6899e393b439ff1f983a91d39d78eeece2e96e401a9dc8a187c52e"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.thymeleaf.extras/thymeleaf-extras-java8time@3.0.4.RELEASE?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "http://www.thymeleaf.org"
+        },
+        {
+          "type" : "distribution-intake",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2"
+        },
+        {
+          "type" : "vcs",
+          "url" : "scm:git:git@github.com:thymeleaf/thymeleaf-extras-java8time.git"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.thymeleaf.extras/thymeleaf-extras-java8time@3.0.4.RELEASE?type=jar"
+    },
+    {
+      "publisher" : "Eclipse Foundation",
+      "group" : "jakarta.xml.bind",
+      "name" : "jakarta.xml.bind-api",
+      "version" : "2.3.3",
+      "description" : "Jakarta XML Binding API",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "61286918ca0192e9f87d1358aef718dd"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "48e3b9cfc10752fba3521d6511f4165bea951801"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "c04539f472e9a6dd0c7685ea82d677282269ab8e7baca2e14500e381e0c6cec5"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "adf6436a7a9dc6f64b97127861d7a89b78e82bea67f72bda800ef285163adcd84dbf006f679108a2a8c2eed013e0b771da2354087e0845479ff2b6318b881442"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "bad8b9f52bf7a7e1d3974cb305a69c093fb32d2131539c18d34e471e3ec32bdd9dd136bb4b38bb14d84e99c562f208c7"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "8131aaf65f996cfa2c3f7d406caab3acf3e6650bcbbcd5595f8a457a211810ff110c1923876e068831a07388ddc26f33"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "a9e4179a6bfa8b363b9fd4f32f8892c4a7954ed1695d3f33ccef73ceffcaa1d4"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "9ecbc0f4aa9cff28d519cbf74c8234b5180ae6ff0d6de4efe2de126b3251d466a5ddb878e70b9968095a843c82721c93a4dec53bfe09e3700f4cfe2e38bcac0a"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "BSD-3-Clause"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/jakarta.xml.bind/jakarta.xml.bind-api@2.3.3?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://github.com/eclipse-ee4j/jaxb-api/jakarta.xml.bind-api"
+        },
+        {
+          "type" : "distribution-intake",
+          "url" : "https://jakarta.oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/eclipse-ee4j/jaxb-api/issues"
+        },
+        {
+          "type" : "mailing-list",
+          "url" : "https://dev.eclipse.org/mhonarc/lists/jaxb-dev"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/eclipse-ee4j/jaxb-api.git/jakarta.xml.bind-api"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/jakarta.xml.bind/jakarta.xml.bind-api@2.3.3?type=jar"
+    },
+    {
+      "publisher" : "Eclipse Foundation",
+      "group" : "jakarta.activation",
+      "name" : "jakarta.activation-api",
+      "version" : "1.2.2",
+      "description" : "Jakarta Activation API jar",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "1cbb480310fa1987f9db7a3ed7118af7"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "99f53adba383cb1bf7c3862844488574b559621f"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "a187a939103aef5849a7af84bd7e27be2d120c410af291437375ffe061f4f09d"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "e3d846ff5f62ad9fef514f0726846c63d4aa74b2bb8f60c76258dba37701f83ae75872401071bf40da40697d43a8a6e36d08fa4ef39fe70797fb6f2b1712599f"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "3e25702596eca7dd48f904b3985d64b4b394d162d3884a907d8b2ee647542808713a42a02f0eeff2c07518a206cc91cf"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "07196bf6c1ba4fe3e14e7690b521d3a156ee136a0b34d93f7a20d485c528c25ed5eeaec013172b08bdc63800fa94fe5d"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "5010f77dbc8c2a28269c7b5b662732ec4a01806f3af9af0b5a12882670303b6e"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "6e63931ef5638e4919b210ef3fffc731d3b91a34bd88cf4b4410e583e28d9e8652377b74dbdb63ba4b7b11b68ded509200737527412984c9d5bc6e5b4b938993"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "BSD-3-Clause"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/jakarta.activation/jakarta.activation-api@1.2.2?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://github.com/eclipse-ee4j/jaf/jakarta.activation-api"
+        },
+        {
+          "type" : "distribution-intake",
+          "url" : "https://jakarta.oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/eclipse-ee4j/jaf/issues/"
+        },
+        {
+          "type" : "mailing-list",
+          "url" : "https://dev.eclipse.org/mhonarc/lists/jakarta.ee-community/"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/eclipse-ee4j/jaf/jakarta.activation-api"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/jakarta.activation/jakarta.activation-api@1.2.2?type=jar"
+    },
+    {
+      "publisher" : "Spring IO",
+      "group" : "org.springframework",
+      "name" : "spring-core",
+      "version" : "5.3.22",
+      "description" : "Spring Core",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "8f768c0706314fb9c71cd5db24a6225a"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "661fc01832716c7eedebf995c6841b2f7117c63d"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "6e97fb95215c583b06098c0a73d27237c6165ccd4f8103e2ded40303382bcba3"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "bc3ca0449e24fa0acdc165bba7d7e44adeac326a022a07de89044001c447a337f5eb8105d76872684a75f5d8e72822011367e79bd2f81ba185678883ddd772a2"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "fd8e922517794d3f1acd7b37da1450594a7eaf92f0148c513b2714e28bc19c0f174af33993b093e90e8a851abe2328e6"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "1ec6036d92de7d4090005e89e9460f52b392ef10fe8c9129aba6fab2489c21bf45db65ee60dc66b7adae88b4a7d8e2dc"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "891916b8b4fb95c0041e259fdabc1cdc9d65ae32c916e2a0a3427fe4b50f9980"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "df2fc08bba65aa8c13f7cd52e9dd72ea99dbdc0a3ace4c62d95d59a243dfcf27a62fc425add0d8f36ecfbc7e91a0bcf2b653b86ad961498dfa74a3ce86dce725"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.springframework/spring-core@5.3.22?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://github.com/spring-projects/spring-framework"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/spring-projects/spring-framework/issues"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/spring-projects/spring-framework"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.springframework/spring-core@5.3.22?type=jar"
+    },
+    {
+      "publisher" : "Spring IO",
+      "group" : "org.springframework",
+      "name" : "spring-jcl",
+      "version" : "5.3.22",
+      "description" : "Spring Commons Logging Bridge",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "ee2f0e6c61acc47fa33c908177c921c0"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "811ace5e5eb379654ed96fd7844809db51af74a5"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "9850007771da9a266a1c8176a7a8387cc33603f5f92dc753afc846dec125c880"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "e4512c191cfb926839aebddea52a214f8571b9062825bda5ad45c7a589fb5e345131f3dac6d44ffb4eab9704036676efe6d58e75d294e7d26deb5de853f22978"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "ded00cbc79e55bff47528595d20c36146b0b0d6aced22b72342c27aad1b3237dfb7542dbd056eeaec8fc1d92f5a0e535"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "57d31acfbedb31488cc7073e6218a084b5d65e558878762a94dd792fa816fc16843dc9f0628150b216f17ab5f133204e"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "1e82255ab13f7488754caf3435d93d7593e944db55b992500c6e58db2dfcde00"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "1eddaca8eb29cef32c1450093011fb678e4fa7ac878d234a6041c54f34b24b53ccc41c2f9d6b7b0fb69250337477364f5691ad7916a95952db7a76eefada8a15"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.springframework/spring-jcl@5.3.22?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://github.com/spring-projects/spring-framework"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/spring-projects/spring-framework/issues"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/spring-projects/spring-framework"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.springframework/spring-jcl@5.3.22?type=jar"
+    },
+    {
+      "group" : "com.h2database",
+      "name" : "h2",
+      "version" : "2.1.214",
+      "description" : "H2 Database Engine",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "93628fb706e682dd989f697394039025"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "d5c2005c9e3279201e12d4776c948578b16bf8b2"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "d623cdc0f61d218cf549a8d09f1c391ff91096116b22e2475475fce4fbe72bd0"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "fedc464dee11077ea3e95149b3c1a1420d6e432c940ccb8c368633821b29c0e401b711d45f819d1cc3755a54ad05fdd0e8bb6b17853dd15539613f5e2765f359"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "a53154e9f52e73228c27602b05f3cc24939dad90cd769f3ba9d3c498b21d53dde054f85f56286a043a941b68ea3ca7fe"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "ac9b13665daa9b745ac1f2584f97623f8323b9966d272c515e51e502f063f0ef2103b2d98bf37e8c35c728a0a597c6c2"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "58e3dd539432b47c8555edf19ef12d78537b9c2f2d775594297ae7a57c97557f"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "30cb7b5fd7bebebfb258a96a6ad5e5d59f68fe16ecf6e5e985dc5b3e7a7319bd5d675e03f7d69a548be07351ba3b25946facbdc3955b8f0bc30edc5c7cc5fd84"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "MPL-2.0"
+          }
+        },
+        {
+          "license" : {
+            "name" : "EPL 1.0",
+            "url" : "https://opensource.org/licenses/eclipse-1.0.php"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/com.h2database/h2@2.1.214?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://h2database.com"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/h2database/h2database"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/com.h2database/h2@2.1.214?type=jar"
+    },
+    {
+      "publisher" : "Oracle Corporation",
+      "group" : "mysql",
+      "name" : "mysql-connector-java",
+      "version" : "8.0.30",
+      "description" : "JDBC Type 4 driver for MySQL",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "ad7ef879830dbf17c7a73bf03b34f6fc"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "b26dd6e4e917d3d4726c34d09d2fd67df7c1dd37"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "b5bf2f0987197c30adf74a9e419b89cda4c257da2d1142871f508416d5f2227a"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "8120c80ad5c23cc5c2fbcd68180d345ce506f637fd2bffc696ddeec2ec37cb570a419fe5b4aad9d53907575ef3fe4f95bcaa4d7655ebea463c4d5b1b9db89759"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "9d706dc7956a556592720be11dd88a3652fdb26f0624654b47523e391a7a14ba7416585e144e27995356e904a65e21a3"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "4c047aadb4fba5a1985a274c9225f230720c457c08f0cd9391a1e1b0a32651825c00fc501a42b2ef58279aa841510d03"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "4322f08ae3e7a33f73d4f140b7259ae0752eeddf0e6a736b49989870468e83a5"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "55d7d5d62f13d13ff9981f6625c53828111abd59c19f7f98836e21d92d904d8e0417302a4805b9a1721a8aabd6f54079ee2bdeb2776e68f7cfbc5af393c774ff"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "name" : "The GNU General Public License, v2 with FOSS exception"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/mysql/mysql-connector-java@8.0.30?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "http://dev.mysql.com/doc/connector-j/en/"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/mysql/mysql-connector-j"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/mysql/mysql-connector-java@8.0.30?type=jar"
+    },
+    {
+      "publisher" : "PostgreSQL Global Development Group",
+      "group" : "org.postgresql",
+      "name" : "postgresql",
+      "version" : "42.3.6",
+      "description" : "PostgreSQL JDBC Driver Postgresql",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "8693d79c6088ab05026dfcb73a811a48"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "98e509e29657cd3633d93bc05ae41ff71fbb79d1"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "43666128a1d1d6b36870b858973a170d3fa6293c969684fe88f42a71140293a0"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "e557147c748e0b6ec21fa772dc48ebda87fb689e57d26cd85fb02d4a9cd09cb6f07e0f17af0746b607b1fe4700ba640fb8de963e87d573b407a013e24163d1d0"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "012a025865b5fcf8df6aa5f1dcf97bc734e8cd1ec301ac07d261cf87b71dcad0671ea514dc8f832e5d2eafe26e6b4bfd"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "444a6223f192127fef300dde39e6a2aff3d24ead2ab01eccd38c4a8e05aba0fdb896221195f6d380b6c483e42b0416a5"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "9ef1375fbace6048c0dc109e506a7c2dcb98d287ef6d207da0034fe7b11af991"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "dac0989440ef4a86f9e339d65f4eac33c391669e0c5d37dbbf29aba13fadd289f81e66606371089a0a4ec37b2c4c845f3800580440ebc61a0d7921f1501b662e"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "BSD-2-Clause",
+            "url" : "https://opensource.org/licenses/BSD-2-Clause"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.postgresql/postgresql@42.3.6?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://jdbc.postgresql.org"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/pgjdbc/pgjdbc/issues"
+        },
+        {
+          "type" : "mailing-list",
+          "url" : "https://www.postgresql.org/list/pgsql-jdbc/"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/pgjdbc/pgjdbc"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.postgresql/postgresql@42.3.6?type=jar"
+    },
+    {
+      "group" : "org.checkerframework",
+      "name" : "checker-qual",
+      "version" : "3.5.0",
+      "description" : "Checker Qual is the set of annotations (qualifiers) and supporting classes used by the Checker Framework to type check Java source code. Please see artifact: org.checkerframework:checker",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "4464def1ed5c10f248ebfe1bccbedf1a"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "2f50520c8abea66fbd8d26e481d3aef5c673b510"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "729990b3f18a95606fc2573836b6958bcdb44cb52bfbd1b7aa9c339cff35a5a4"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "407d0ac59b02cbef7d93f25c8b287cd587232aa5ddfee6d2c7ba34d712565b0a5adfe52b5daa20d3e6c3ab1e7a5f8b08698078d9179185a1b35ada1eb92213bf"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "01fb1d7a7440f807b2bdb697c709dfa5897edc0755152c0fef465cf77dd820623fccb410ad033e3d52d4b0bc57409ecf"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "626beff2173578c3a2ad732c81c48a9b091c9ffdea7d50f4b812fd14cd8299ab7a726b052808490b1022faca69aa6e91"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "4fbe95b196e75e549f66831e9b1f8f46cfe1793f4fda350857f5f24349d74af1"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "2c84365b1fcd16a765e49c5d8f30f28c3fe7cfe868ac32be726d8b9351c9053ffea23cfa1db9fb5c59c9928d22ad01c3c894d798e115bc446447228c7c4b24c6"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "MIT"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.checkerframework/checker-qual@3.5.0?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://checkerframework.org"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/typetools/checker-framework.git"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.checkerframework/checker-qual@3.5.0?type=jar"
+    },
+    {
+      "group" : "javax.cache",
+      "name" : "cache-api",
+      "version" : "1.1.1",
+      "description" : "Sonatype helps open source projects to set up Maven repositories on https://oss.sonatype.org/",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "dfdac9358e140e61c574abb1ada84dc9"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "c56fb980eb5208bfee29a9a5b9d951aba076bd91"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "9f34e007edfa82a7b2a2e1b969477dcf5099ce7f4f926fb54ce7e27c4a0cd54b"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "7e2c2e421c46d66f35ae0c107c31ae28606562190871655efd38c60b335a10b1770134f88c8aada5a389e9e364be885713fe7d0464c2a9fbea06ec1102b2c3e5"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "3740a5ddb6bf6d1627190fbabf06ffc19fb84a488c120ebf1bbc6407971905c7f415310a17c8db77ee90d09cb2301d3d"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "49c3aca710ab2ad62e4610ad0f3b76338079aa49e90e84cb18b59ced56caf9f6e2bc855e9900cb1b7748a1f3e0d160e2"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "ed71d13b59b8ebba5fb3f2f42da03e29d1fdaefef8fde375794a6598fdb702be"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "8b93ce37a0ea13bcb8f35a0237307f7b232c178d11e452d02c4383dbd51531eeb4a3c722778dfb95637412e6451a132f6031f0f4e3d51928a6b857160269dec0"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/javax.cache/cache-api@1.1.1?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://github.com/jsr107/jsr107spec"
+        },
+        {
+          "type" : "distribution-intake",
+          "url" : "http://oss.sonatype.org/service/local/staging/deploy/maven2"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/javax.cache/cache-api@1.1.1?type=jar"
+    },
+    {
+      "publisher" : "Terracotta Inc., a wholly-owned subsidiary of Software AG USA, Inc.",
+      "group" : "org.ehcache",
+      "name" : "ehcache",
+      "version" : "3.10.0",
+      "description" : "End-user ehcache3 jar artifact",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "29e7d123ba8caa52888adff98afd9e1c"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "7dbd8976ae8087f5db27be48abd4a238fce52765"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "3b8c765f23665ae1296a41d711825abfbc18fde5de14e383ef7144023bb4ff7e"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "223964f54a067e9d5f1a123a462d5aaf89c9db7e370ba6d4599420cfabd3fdd461d68b736872a03a2ade0a39519420eb9767bd89eacca32a526c8a670a881fd6"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "10b1a2ccc2fee4724f0dc8a0a75c3839251ada7c5000b720d1c502fb8b9a11cd6b79bbd99e61aee526ef32e96be9f231"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "576d8d9a2f898aafc781c4e0419db6ccc4beb89a5eb8bee622dc51fb99e6bc1a3034360191f0705d042386cfa90ce069"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "e6923696025a6deed43a7e65f52033c5cf460a4cf4ad55d427e1cbac0121b5b9"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "11ed78118ca42acf3e798a7cfbf11ccc3865eed90a8e76e6cbc7e9b444889299ba2c1d44389f2201ce27d30d2dde4f6e878123f829bba40fa43f3a4bb0148e74"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.ehcache/ehcache@3.10.0?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "http://ehcache.org"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/ehcache/ehcache3/issues"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/ehcache/ehcache3"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.ehcache/ehcache@3.10.0?type=jar"
+    },
+    {
+      "publisher" : "QOS.ch",
+      "group" : "org.slf4j",
+      "name" : "slf4j-api",
+      "version" : "1.7.36",
+      "description" : "The slf4j API",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "872da51f5de7f3923da4de871d57fd85"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "6c62681a2f655b49963a5983b8b0950a6120ae14"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "d3ef575e3e4979678dc01bf1dcce51021493b4d11fb7f1be8ad982877c16a1c0"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "f9b033fc019a44f98b16048da7e2b59edd4a6a527ba60e358f65ab88e0afae03a9340f1b3e8a543d49fa542290f499c5594259affa1ff3e6e7bf3b428d4c610b"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "2b14ad035877087157e379d3277dcdcd79e58d6bdb147c47d29e377d75ce53ad42cafbf22f5fb7827c7e946ff4876b9a"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "3bc3110dafb8d5be16a39f3b2671a466463cd99eb39610c0e4719a7bf2d928f2ea213c734887c6926a07c4cca7769e4b"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "ba2608179fcf46e2291a90b9cbb4aa30d718e481f59c350cc21c73b88d826881"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "14c4edcd19702ef607d78826839d8a6d3a39157df54b89a801d3d3cbbe1307131a77671b041c761122730fb1387888c5ec2e46bdd80e1cb07f8f144676441824"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "MIT",
+            "url" : "https://opensource.org/licenses/MIT"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.slf4j/slf4j-api@1.7.36?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "http://www.slf4j.org"
+        },
+        {
+          "type" : "distribution-intake",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/qos-ch/slf4j/slf4j-api"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.slf4j/slf4j-api@1.7.36?type=jar"
+    },
+    {
+      "publisher" : "Eclipse Foundation",
+      "group" : "org.glassfish.jaxb",
+      "name" : "jaxb-runtime",
+      "version" : "2.3.6",
+      "description" : "JAXB (JSR 222) Reference Implementation",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "29acad12b7cdd22b2a5ab66cd7439d48"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "1e6cd0e5d9f9919c8c8824fb4d310b09a978a60e"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "cd87d4b98a8bec1d237aed61472ef4adb6a8bb0515cbde1fd62fdd9781c16770"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "8e8042f4a2a45f3520ce6376d826c0445a54509a728f9f61b274c2e2d92d242bfabfba112994d0df56f59f58c48e4069fb2dabf0fcc67208e651597de5eeaa98"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "6c3cfac49412ee125c0183e39ef751b8a7db04f02133ca6e039259708d2bd36df88bca3163672c8ab809cca9824e8d7e"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "3a0e2fbe2231fb39ae58afc52ad6dabf3cb932d4b56116f5ed3697b57bd0970c915e1f2b14df48576277c50ebb055a3b"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "00c4b10fb5581894c010618d4af73b821fbc262d883e5e1089438efa72243668"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "f5657b09370ecd381e76148b52fd8aa8e904f09424f2c7df5307b11ac0403db885d8a82e50002047c5be4c532c8f5778bd11833beebef3ddfe02fbf2fd35b464"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "BSD-3-Clause"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.glassfish.jaxb/jaxb-runtime@2.3.6?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://eclipse-ee4j.github.io/jaxb-ri/"
+        },
+        {
+          "type" : "distribution-intake",
+          "url" : "https://jakarta.oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/eclipse-ee4j/jaxb-ri/issues"
+        },
+        {
+          "type" : "mailing-list",
+          "url" : "https://accounts.eclipse.org/mailing-list/jaxb-impl-dev"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/eclipse-ee4j/jaxb-ri.git/jaxb-runtime-parent/jaxb-runtime"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.glassfish.jaxb/jaxb-runtime@2.3.6?type=jar"
+    },
+    {
+      "publisher" : "Eclipse Foundation",
+      "group" : "org.glassfish.jaxb",
+      "name" : "txw2",
+      "version" : "2.3.6",
+      "description" : "TXW is a library that allows you to write XML documents.",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "dd02e61e4662e6461f0c21b08e721021"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "45db7b69a8f1ec2c21eb7d4fc0ee729f53c1addc"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "f8bc249d22ad950257c373aea80c2f16f18f5eb4d557bdb2660bf5e1f1e84776"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "468cd89821480364a49f73f1774383fd483fd8273d373601a4867b37267f125c3fdf3ffd8a73a114408699137c469c02e47f94b80c7d21df236b4a187d12680d"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "02c99a070c038081922bdae47cd9e739045342b223c55204716bba9f81eca971ed1313eab8bb103dc596bfd7b84a6b72"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "e63ebe6d86a51506c45b430c8a71d80ac0fa95f99692a30697468b242ccd5c818f5d4aaf967e049797fee704a92307db"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "585be97a69d2a94b6647330ac36b3d5b2389eadfb92138f2b80a3e8c3bcc4b63"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "2e7ed6f7267f7e4eb0c0b0e89f845fcd253eec4ab1fa66fd915b7a4bd738e881c9e8f801af17dbbbfbc4311409f0fad9737780693a1018582e307a3293d27405"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "BSD-3-Clause"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.glassfish.jaxb/txw2@2.3.6?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://eclipse-ee4j.github.io/jaxb-ri/"
+        },
+        {
+          "type" : "distribution-intake",
+          "url" : "https://jakarta.oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/eclipse-ee4j/jaxb-ri/issues"
+        },
+        {
+          "type" : "mailing-list",
+          "url" : "https://accounts.eclipse.org/mailing-list/jaxb-impl-dev"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/eclipse-ee4j/jaxb-ri.git/jaxb-txw-parent/txw2"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.glassfish.jaxb/txw2@2.3.6?type=jar"
+    },
+    {
+      "publisher" : "Eclipse Foundation",
+      "group" : "com.sun.istack",
+      "name" : "istack-commons-runtime",
+      "version" : "3.0.12",
+      "description" : "istack common utility code",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "1952bd76321f8580cfaa57e332a68287"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "cbbe1a62b0cc6c85972e99d52aaee350153dc530"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "27d85fc134c9271d5c79d3300fc4669668f017e72409727c428f54f2417f04cd"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "af36b11cc0d82b7f62c64941f4e7d441d25cb9f3c4b3e08753d038c388e5a09364b5dac9127f29a9b8df6d96034133caadab6d74371077478d2f301605913460"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "ad8ba1f6538e087915b1e7fbf4a7a60b006ebecc4ab52986c10dfe88ae11ae7eb6e1f302bee06f70b16ec316f001375b"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "2207c7e1570860d6300ef3157905498efaf26ba85566b053495f583b20c755cc07d6855b2d79136ab4d6544635e39f4d"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "50a425e524a6ee81110ecd86190d039a84d46aa3c45855310fe4f95abba3c21e"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "286997280ee0885c456686cf91c601e600106138f39eb81fc27381868f7ede0d1521cdf22c420331b1a961ed2f1ba1887a9ae05073f4364e3ffc297f40f0de53"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "BSD-3-Clause"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/com.sun.istack/istack-commons-runtime@3.0.12?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://projects.eclipse.org/projects/ee4j/istack-commons/istack-commons-runtime"
+        },
+        {
+          "type" : "distribution-intake",
+          "url" : "https://jakarta.oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/eclipse-ee4j/jaxb-istack-commons/issues"
+        },
+        {
+          "type" : "mailing-list",
+          "url" : "https://dev.eclipse.org/mhonarc/lists/jaxb-impl-dev"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/eclipse-ee4j/jaxb-istack-commons/istack-commons-runtime"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/com.sun.istack/istack-commons-runtime@3.0.12?type=jar"
+    },
+    {
+      "publisher" : "Eclipse Foundation",
+      "group" : "com.sun.activation",
+      "name" : "jakarta.activation",
+      "version" : "1.2.2",
+      "description" : "Jakarta Activation",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "0b8bee3bf29b9a015f8b992035581a7c"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "74548703f9851017ce2f556066659438019e7eb5"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "02156773e4ae9d048d14a56ad35d644bee9f1052a791d072df3ded3c656e6e1a"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "8bd94a4370b827e3904f31253b022e5c1851896d3b616ca7daebfef259238cedc56d4ced32c74f24a13c3e2295b0ea012af5d04656b7f713cc53a2f18d5e2cf7"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "1cb0aff8b73ba52a9931b2cf13c75a1ce6665fb826bf97ede66db75c532136aa189fb53a1925e62b6eef572309ef3b9a"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "83801332576d931f4091ba65ea240d49c23e3b93dae939ce2eed63de943f80f251a4347638b99900de5b831796b12590"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "5363211b59dfaff6e1973e93548e5e4062189c6d0f43d7802627ebeb7b7ff37d"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "0c7b62a3432b19ffad02eafffc7e598391cd32b1313d075f94cda09913402770b4ba2314716625571f266431067229c93cec36e17c3ea598623542988634ca0a"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "BSD-3-Clause"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/com.sun.activation/jakarta.activation@1.2.2?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://github.com/eclipse-ee4j/jaf/jakarta.activation"
+        },
+        {
+          "type" : "distribution-intake",
+          "url" : "https://jakarta.oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/eclipse-ee4j/jaf/issues/"
+        },
+        {
+          "type" : "mailing-list",
+          "url" : "https://dev.eclipse.org/mhonarc/lists/jakarta.ee-community/"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/eclipse-ee4j/jaf/jakarta.activation"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/com.sun.activation/jakarta.activation@1.2.2?type=jar"
+    },
+    {
+      "group" : "org.webjars.npm",
+      "name" : "bootstrap",
+      "version" : "5.1.3",
+      "description" : "WebJar for bootstrap",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "3df1c150436df8659cfa05fa231e0910"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "884629733aed9d55a20b8db921335849abb6732f"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "fec359661b76788128e2ce0b509272eb1151126824b6d95f665e53a58a5fc501"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "bff68d5433af6973b50d6399ae67b0bfaeee22dade7a667e3bf92b52aaf6dc20c7c3b6fdcc1c25f40a2c181d6267ab29ca8590c05e31a307e36c4d3fa462144b"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "cf2109654f924573ec4aaf7bb31301254e40b355679f5d3da0a1ed03d164e4459ae8337c00f2368d124e3ef194708781"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "ca1c90e380c647598e602ce9be5cd31a88b42b59033494122a4d5d89ae73b447aa2702ad0cb3bd69af019fc0dec344bc"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "9850f135d21dfdf98a3cc46397f66a6da4f8f973983d2377f07d74c2392effbe"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "57fe1058d4ea9d2159a69c205444af5bde2e540077983a4af9ff7c795c2e67576a1f077b69d5d4f31db20c23c606e9b2f0a09333b44a34d9f16c17373a3f4ae6"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "MIT",
+            "url" : "https://opensource.org/licenses/MIT"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.webjars.npm/bootstrap@5.1.3?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://www.webjars.org"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/twbs/bootstrap/issues"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/twbs/bootstrap"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.webjars.npm/bootstrap@5.1.3?type=jar"
+    },
+    {
+      "group" : "org.webjars.npm",
+      "name" : "font-awesome",
+      "version" : "4.7.0",
+      "description" : "WebJar for font-awesome",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "d01d4fbc4870714c76341ca06ea80525"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "309276dbcb8afe0482a1698a78b081b918e0e445"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "d786751120afe993113902d3eaccb4f596cfd5c98583a2abd76f6a57a8af865a"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "d70796ec3ce97c137606c2b5b9f674336ab6a7e9908b0089b838f4ef9b42b3fa5800aef11a495ec44c82d5a15b6c7597bd75b78824dcc7ed181ca6412e4d9be9"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "cfa0790f78e863140a454385cd2d619de59e4a01fc2a1df9d2a59aa1e3829e3882b3590729d664e42478e6f8628ac958"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "f6789e70bcde46eec4db08b18203e84183ccbe952ceecb0f36974c647af0aeb03a1dac1a4f731b4fc4b8fd1eaedb5c7c"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "8026292f96b797582e60b953d1fc8a7326db0ee3ee136922f15cfdba373db347"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "b4edd32c8a74d4fafa970a01fc3256cbeea90f9c89ce94aa0206789cf08ea9c1f897f6c2b7615affd6202d03e9fdb835b07a50716503dd457a274c70e37f38a7"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "name" : "Openfont-1.1",
+            "url" : "https://spdx.org/licenses/Openfont-1.1#licenseText"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.webjars.npm/font-awesome@4.7.0?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "http://webjars.org"
+        },
+        {
+          "type" : "vcs",
+          "url" : "git+https://github.com/FortAwesome/Font-Awesome"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.webjars.npm/font-awesome@4.7.0?type=jar"
+    },
+    {
+      "publisher" : "Pivotal Software, Inc.",
+      "group" : "org.springframework.boot",
+      "name" : "spring-boot-devtools",
+      "version" : "2.7.3",
+      "description" : "Spring Boot Developer Tools",
+      "scope" : "optional",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "c15cf64bd43d6f0e1a367fc26aab7704"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "ea46ce1fc8c0581f2455dcc43a11768660d87388"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "a9bfb3b438f7c1b0c666c033803b7a8d5b607f526e2ef47daa3f7bd72a469071"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "8443d117fcfe06d60b68b890c9a22771a47c77a9428e7c7519f8c30002a5e662abd39c81d3ba1a0f112c30bacb3310f370af4b5ddcc47c6637b2e58c07d1a237"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "c508a02a7275ac8a9930da4f95f3b7a1627f58ab487e5de43f172b674cf57c472f9ce729170382e4501c42fd6f4f059e"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "a45a100b01e7124ce77765f714bafb30cc4246b4bf867d05b1f2c893501dfe7fe8bbb86fba9c366b7314cca6a3736c50"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "e442479718ac52c84f5c43e242a55ac042828775ccf8010b8db86a56740fa334"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "20e17e184b4f65975c5a5732cdb45152ec4738938b2f26c0b7e5825d00f7c63e4af1b3fb3d068bd3b83e0ec3a22c295e10f53d4b81ca98f2dd1aba5588d85b6c"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.springframework.boot/spring-boot-devtools@2.7.3?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://spring.io/projects/spring-boot"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/spring-projects/spring-boot/issues"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/spring-projects/spring-boot"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.springframework.boot/spring-boot-devtools@2.7.3?type=jar"
+    },
+    {
+      "publisher" : "Pivotal Software, Inc.",
+      "group" : "org.springframework.boot",
+      "name" : "spring-boot",
+      "version" : "2.7.3",
+      "description" : "Spring Boot",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "ac0034bdd663b8f79bbb876d29821427"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "3a8d641077565b7eaec3b2f91d5b83a6800f5895"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "b7e0a7ab7292a8827e34f86867a8fdf8354c7585c2db4fc6c802ede56fe07d3c"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "625436d3710bf80dc81fa47e5e9148e10a677733b4a2e5be9ab863ccdbd944c0fd5714b7427a4a12fd06e72741cc2db8c0b013cff879c0ef064927282b39e8a1"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "ff1d07b7d31b56a6f567e6a8dc44fc176a022dc2e1d46feb2a9b4ae77b22b7069a700944db9bc90e9e8528d83ff7941c"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "4dc092d53b9de209a890dffe7e43399efc38ee082221270f8982f882ae43b245989073d0971fbc38efb40efbbbeedcc1"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "8a3e5a2f4d628c4e44951b1ce2f1f2c1d1b8d62e74c3d4d314e41fd4cd94f2cc"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "32574d1caa708ef730787083fcc9d2f35845c3cc8d96bad1b23388b486e03400ef1ad826e3ac469d64fcbe81f5b452fa2f50aa18ab84fb637754063f3b39a565"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.springframework.boot/spring-boot@2.7.3?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://spring.io/projects/spring-boot"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/spring-projects/spring-boot/issues"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/spring-projects/spring-boot"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.springframework.boot/spring-boot@2.7.3?type=jar"
+    },
+    {
+      "publisher" : "Pivotal Software, Inc.",
+      "group" : "org.springframework.boot",
+      "name" : "spring-boot-autoconfigure",
+      "version" : "2.7.3",
+      "description" : "Spring Boot AutoConfigure",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "5b7ff135649bab33112ee1a590c24ad9"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "4c96169e8d71c9c41f07a40d011dbd41898180ac"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "a54b67cd971f856098e05ed13967596220a1898563a2552252234793e2fa8e63"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "5cf8bc76aaa3b8a6c5e3acf84555e5a326fa67f3391ad51a5853a43ba537174b3d19a813292bbf4110a95225b43ab8d96c1704aab74cec81fa3b595f165a0a84"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "8dfaa4bfa43f12f8497c72c7d9cbc45dd19762ac1ae2169283cdd81b616c5b810227a2ed03430f2be98fbd72d461f5ba"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "081f551d31a703353c0bb368a978c146a1c4edcfa96702dbe9322442784bcd2f9d95076b9f309ca3df306d4d05146a5e"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "e5bed6eba9a01fce9bea7c577d3bc158e96cef3aae7a41cb6933eb3cadcdef94"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "2dd4d92a7bcd4abfba948c956e50675ba34257cb6dc0ca9ecd89dd02b4cd89b5e04e3b7e37271ed25dbad058e65e6cab169d0516e42efb16540754eb97a386d4"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.springframework.boot/spring-boot-autoconfigure@2.7.3?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://spring.io/projects/spring-boot"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/spring-projects/spring-boot/issues"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/spring-projects/spring-boot"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.springframework.boot/spring-boot-autoconfigure@2.7.3?type=jar"
+    }
+  ],
+  "dependencies" : [
+    {
+      "ref" : "pkg:maven/org.springframework.samples/spring-petclinic@2.7.3?type=jar",
+      "dependsOn" : [
+        "pkg:maven/org.springframework.boot/spring-boot-starter-actuator@2.7.3?type=jar",
+        "pkg:maven/org.springframework.boot/spring-boot-starter-cache@2.7.3?type=jar",
+        "pkg:maven/org.springframework.boot/spring-boot-starter-data-jpa@2.7.3?type=jar",
+        "pkg:maven/org.springframework.boot/spring-boot-starter-web@2.7.3?type=jar",
+        "pkg:maven/org.springframework.boot/spring-boot-starter-validation@2.7.3?type=jar",
+        "pkg:maven/org.springframework.boot/spring-boot-starter-thymeleaf@2.7.3?type=jar",
+        "pkg:maven/com.h2database/h2@2.1.214?type=jar",
+        "pkg:maven/mysql/mysql-connector-java@8.0.30?type=jar",
+        "pkg:maven/org.postgresql/postgresql@42.3.6?type=jar",
+        "pkg:maven/javax.cache/cache-api@1.1.1?type=jar",
+        "pkg:maven/org.ehcache/ehcache@3.10.0?type=jar",
+        "pkg:maven/org.webjars.npm/bootstrap@5.1.3?type=jar",
+        "pkg:maven/org.webjars.npm/font-awesome@4.7.0?type=jar",
+        "pkg:maven/org.springframework.boot/spring-boot-devtools@2.7.3?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/org.springframework.boot/spring-boot-starter-actuator@2.7.3?type=jar",
+      "dependsOn" : [
+        "pkg:maven/org.springframework.boot/spring-boot-starter@2.7.3?type=jar",
+        "pkg:maven/org.springframework.boot/spring-boot-actuator-autoconfigure@2.7.3?type=jar",
+        "pkg:maven/io.micrometer/micrometer-core@1.9.3?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/org.springframework.boot/spring-boot-starter@2.7.3?type=jar",
+      "dependsOn" : [
+        "pkg:maven/org.springframework.boot/spring-boot@2.7.3?type=jar",
+        "pkg:maven/org.springframework.boot/spring-boot-autoconfigure@2.7.3?type=jar",
+        "pkg:maven/org.springframework.boot/spring-boot-starter-logging@2.7.3?type=jar",
+        "pkg:maven/jakarta.annotation/jakarta.annotation-api@1.3.5?type=jar",
+        "pkg:maven/org.springframework/spring-core@5.3.22?type=jar",
+        "pkg:maven/org.yaml/snakeyaml@1.30?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/org.springframework.boot/spring-boot@2.7.3?type=jar",
+      "dependsOn" : [
+        "pkg:maven/org.springframework/spring-core@5.3.22?type=jar",
+        "pkg:maven/org.springframework/spring-context@5.3.22?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/org.springframework/spring-core@5.3.22?type=jar",
+      "dependsOn" : [
+        "pkg:maven/org.springframework/spring-jcl@5.3.22?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/org.springframework/spring-jcl@5.3.22?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/org.springframework/spring-context@5.3.22?type=jar",
+      "dependsOn" : [
+        "pkg:maven/org.springframework/spring-aop@5.3.22?type=jar",
+        "pkg:maven/org.springframework/spring-beans@5.3.22?type=jar",
+        "pkg:maven/org.springframework/spring-core@5.3.22?type=jar",
+        "pkg:maven/org.springframework/spring-expression@5.3.22?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/org.springframework/spring-aop@5.3.22?type=jar",
+      "dependsOn" : [
+        "pkg:maven/org.springframework/spring-beans@5.3.22?type=jar",
+        "pkg:maven/org.springframework/spring-core@5.3.22?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/org.springframework/spring-beans@5.3.22?type=jar",
+      "dependsOn" : [
+        "pkg:maven/org.springframework/spring-core@5.3.22?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/org.springframework/spring-expression@5.3.22?type=jar",
+      "dependsOn" : [
+        "pkg:maven/org.springframework/spring-core@5.3.22?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/org.springframework.boot/spring-boot-autoconfigure@2.7.3?type=jar",
+      "dependsOn" : [
+        "pkg:maven/org.springframework.boot/spring-boot@2.7.3?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/org.springframework.boot/spring-boot-starter-logging@2.7.3?type=jar",
+      "dependsOn" : [
+        "pkg:maven/ch.qos.logback/logback-classic@1.2.11?type=jar",
+        "pkg:maven/org.apache.logging.log4j/log4j-to-slf4j@2.17.2?type=jar",
+        "pkg:maven/org.slf4j/jul-to-slf4j@1.7.36?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/ch.qos.logback/logback-classic@1.2.11?type=jar",
+      "dependsOn" : [
+        "pkg:maven/ch.qos.logback/logback-core@1.2.11?type=jar",
+        "pkg:maven/org.slf4j/slf4j-api@1.7.36?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/ch.qos.logback/logback-core@1.2.11?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/org.slf4j/slf4j-api@1.7.36?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/org.apache.logging.log4j/log4j-to-slf4j@2.17.2?type=jar",
+      "dependsOn" : [
+        "pkg:maven/org.slf4j/slf4j-api@1.7.36?type=jar",
+        "pkg:maven/org.apache.logging.log4j/log4j-api@2.17.2?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/org.apache.logging.log4j/log4j-api@2.17.2?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/org.slf4j/jul-to-slf4j@1.7.36?type=jar",
+      "dependsOn" : [
+        "pkg:maven/org.slf4j/slf4j-api@1.7.36?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/jakarta.annotation/jakarta.annotation-api@1.3.5?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/org.yaml/snakeyaml@1.30?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/org.springframework.boot/spring-boot-actuator-autoconfigure@2.7.3?type=jar",
+      "dependsOn" : [
+        "pkg:maven/org.springframework.boot/spring-boot-actuator@2.7.3?type=jar",
+        "pkg:maven/org.springframework.boot/spring-boot@2.7.3?type=jar",
+        "pkg:maven/org.springframework.boot/spring-boot-autoconfigure@2.7.3?type=jar",
+        "pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.13.3?type=jar",
+        "pkg:maven/com.fasterxml.jackson.datatype/jackson-datatype-jsr310@2.13.3?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/org.springframework.boot/spring-boot-actuator@2.7.3?type=jar",
+      "dependsOn" : [
+        "pkg:maven/org.springframework.boot/spring-boot@2.7.3?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.13.3?type=jar",
+      "dependsOn" : [
+        "pkg:maven/com.fasterxml.jackson.core/jackson-annotations@2.13.3?type=jar",
+        "pkg:maven/com.fasterxml.jackson.core/jackson-core@2.13.3?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/com.fasterxml.jackson.core/jackson-annotations@2.13.3?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/com.fasterxml.jackson.core/jackson-core@2.13.3?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/com.fasterxml.jackson.datatype/jackson-datatype-jsr310@2.13.3?type=jar",
+      "dependsOn" : [
+        "pkg:maven/com.fasterxml.jackson.core/jackson-annotations@2.13.3?type=jar",
+        "pkg:maven/com.fasterxml.jackson.core/jackson-core@2.13.3?type=jar",
+        "pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.13.3?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/io.micrometer/micrometer-core@1.9.3?type=jar",
+      "dependsOn" : [
+        "pkg:maven/org.hdrhistogram/HdrHistogram@2.1.12?type=jar",
+        "pkg:maven/org.latencyutils/LatencyUtils@2.0.3?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/org.hdrhistogram/HdrHistogram@2.1.12?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/org.latencyutils/LatencyUtils@2.0.3?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/org.springframework.boot/spring-boot-starter-cache@2.7.3?type=jar",
+      "dependsOn" : [
+        "pkg:maven/org.springframework.boot/spring-boot-starter@2.7.3?type=jar",
+        "pkg:maven/org.springframework/spring-context-support@5.3.22?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/org.springframework/spring-context-support@5.3.22?type=jar",
+      "dependsOn" : [
+        "pkg:maven/org.springframework/spring-beans@5.3.22?type=jar",
+        "pkg:maven/org.springframework/spring-context@5.3.22?type=jar",
+        "pkg:maven/org.springframework/spring-core@5.3.22?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/org.springframework.boot/spring-boot-starter-data-jpa@2.7.3?type=jar",
+      "dependsOn" : [
+        "pkg:maven/org.springframework.boot/spring-boot-starter-aop@2.7.3?type=jar",
+        "pkg:maven/org.springframework.boot/spring-boot-starter-jdbc@2.7.3?type=jar",
+        "pkg:maven/jakarta.transaction/jakarta.transaction-api@1.3.3?type=jar",
+        "pkg:maven/jakarta.persistence/jakarta.persistence-api@2.2.3?type=jar",
+        "pkg:maven/org.hibernate/hibernate-core@5.6.10.Final?type=jar",
+        "pkg:maven/org.springframework.data/spring-data-jpa@2.7.2?type=jar",
+        "pkg:maven/org.springframework/spring-aspects@5.3.22?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/org.springframework.boot/spring-boot-starter-aop@2.7.3?type=jar",
+      "dependsOn" : [
+        "pkg:maven/org.springframework.boot/spring-boot-starter@2.7.3?type=jar",
+        "pkg:maven/org.springframework/spring-aop@5.3.22?type=jar",
+        "pkg:maven/org.aspectj/aspectjweaver@1.9.7?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/org.aspectj/aspectjweaver@1.9.7?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/org.springframework.boot/spring-boot-starter-jdbc@2.7.3?type=jar",
+      "dependsOn" : [
+        "pkg:maven/org.springframework.boot/spring-boot-starter@2.7.3?type=jar",
+        "pkg:maven/com.zaxxer/HikariCP@4.0.3?type=jar",
+        "pkg:maven/org.springframework/spring-jdbc@5.3.22?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/com.zaxxer/HikariCP@4.0.3?type=jar",
+      "dependsOn" : [
+        "pkg:maven/org.slf4j/slf4j-api@1.7.36?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/org.springframework/spring-jdbc@5.3.22?type=jar",
+      "dependsOn" : [
+        "pkg:maven/org.springframework/spring-beans@5.3.22?type=jar",
+        "pkg:maven/org.springframework/spring-core@5.3.22?type=jar",
+        "pkg:maven/org.springframework/spring-tx@5.3.22?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/org.springframework/spring-tx@5.3.22?type=jar",
+      "dependsOn" : [
+        "pkg:maven/org.springframework/spring-beans@5.3.22?type=jar",
+        "pkg:maven/org.springframework/spring-core@5.3.22?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/jakarta.transaction/jakarta.transaction-api@1.3.3?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/jakarta.persistence/jakarta.persistence-api@2.2.3?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/org.hibernate/hibernate-core@5.6.10.Final?type=jar",
+      "dependsOn" : [
+        "pkg:maven/org.jboss.logging/jboss-logging@3.4.3.Final?type=jar",
+        "pkg:maven/net.bytebuddy/byte-buddy@1.12.13?type=jar",
+        "pkg:maven/antlr/antlr@2.7.7?type=jar",
+        "pkg:maven/org.jboss/jandex@2.4.2.Final?type=jar",
+        "pkg:maven/com.fasterxml/classmate@1.5.1?type=jar",
+        "pkg:maven/org.hibernate.common/hibernate-commons-annotations@5.1.2.Final?type=jar",
+        "pkg:maven/org.glassfish.jaxb/jaxb-runtime@2.3.6?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/org.jboss.logging/jboss-logging@3.4.3.Final?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/net.bytebuddy/byte-buddy@1.12.13?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/antlr/antlr@2.7.7?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/org.jboss/jandex@2.4.2.Final?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/com.fasterxml/classmate@1.5.1?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/org.hibernate.common/hibernate-commons-annotations@5.1.2.Final?type=jar",
+      "dependsOn" : [
+        "pkg:maven/org.jboss.logging/jboss-logging@3.4.3.Final?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/org.glassfish.jaxb/jaxb-runtime@2.3.6?type=jar",
+      "dependsOn" : [
+        "pkg:maven/jakarta.xml.bind/jakarta.xml.bind-api@2.3.3?type=jar",
+        "pkg:maven/org.glassfish.jaxb/txw2@2.3.6?type=jar",
+        "pkg:maven/com.sun.istack/istack-commons-runtime@3.0.12?type=jar",
+        "pkg:maven/com.sun.activation/jakarta.activation@1.2.2?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/jakarta.xml.bind/jakarta.xml.bind-api@2.3.3?type=jar",
+      "dependsOn" : [
+        "pkg:maven/jakarta.activation/jakarta.activation-api@1.2.2?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/jakarta.activation/jakarta.activation-api@1.2.2?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/org.glassfish.jaxb/txw2@2.3.6?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/com.sun.istack/istack-commons-runtime@3.0.12?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/com.sun.activation/jakarta.activation@1.2.2?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/org.springframework.data/spring-data-jpa@2.7.2?type=jar",
+      "dependsOn" : [
+        "pkg:maven/org.springframework.data/spring-data-commons@2.7.2?type=jar",
+        "pkg:maven/org.springframework/spring-orm@5.3.22?type=jar",
+        "pkg:maven/org.springframework/spring-context@5.3.22?type=jar",
+        "pkg:maven/org.springframework/spring-aop@5.3.22?type=jar",
+        "pkg:maven/org.springframework/spring-tx@5.3.22?type=jar",
+        "pkg:maven/org.springframework/spring-beans@5.3.22?type=jar",
+        "pkg:maven/org.springframework/spring-core@5.3.22?type=jar",
+        "pkg:maven/org.slf4j/slf4j-api@1.7.36?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/org.springframework.data/spring-data-commons@2.7.2?type=jar",
+      "dependsOn" : [
+        "pkg:maven/org.springframework/spring-core@5.3.22?type=jar",
+        "pkg:maven/org.springframework/spring-beans@5.3.22?type=jar",
+        "pkg:maven/org.slf4j/slf4j-api@1.7.36?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/org.springframework/spring-orm@5.3.22?type=jar",
+      "dependsOn" : [
+        "pkg:maven/org.springframework/spring-beans@5.3.22?type=jar",
+        "pkg:maven/org.springframework/spring-core@5.3.22?type=jar",
+        "pkg:maven/org.springframework/spring-jdbc@5.3.22?type=jar",
+        "pkg:maven/org.springframework/spring-tx@5.3.22?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/org.springframework/spring-aspects@5.3.22?type=jar",
+      "dependsOn" : [
+        "pkg:maven/org.aspectj/aspectjweaver@1.9.7?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/org.springframework.boot/spring-boot-starter-web@2.7.3?type=jar",
+      "dependsOn" : [
+        "pkg:maven/org.springframework.boot/spring-boot-starter@2.7.3?type=jar",
+        "pkg:maven/org.springframework.boot/spring-boot-starter-json@2.7.3?type=jar",
+        "pkg:maven/org.springframework.boot/spring-boot-starter-tomcat@2.7.3?type=jar",
+        "pkg:maven/org.springframework/spring-web@5.3.22?type=jar",
+        "pkg:maven/org.springframework/spring-webmvc@5.3.22?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/org.springframework.boot/spring-boot-starter-json@2.7.3?type=jar",
+      "dependsOn" : [
+        "pkg:maven/org.springframework.boot/spring-boot-starter@2.7.3?type=jar",
+        "pkg:maven/org.springframework/spring-web@5.3.22?type=jar",
+        "pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.13.3?type=jar",
+        "pkg:maven/com.fasterxml.jackson.datatype/jackson-datatype-jdk8@2.13.3?type=jar",
+        "pkg:maven/com.fasterxml.jackson.datatype/jackson-datatype-jsr310@2.13.3?type=jar",
+        "pkg:maven/com.fasterxml.jackson.module/jackson-module-parameter-names@2.13.3?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/org.springframework/spring-web@5.3.22?type=jar",
+      "dependsOn" : [
+        "pkg:maven/org.springframework/spring-beans@5.3.22?type=jar",
+        "pkg:maven/org.springframework/spring-core@5.3.22?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/com.fasterxml.jackson.datatype/jackson-datatype-jdk8@2.13.3?type=jar",
+      "dependsOn" : [
+        "pkg:maven/com.fasterxml.jackson.core/jackson-core@2.13.3?type=jar",
+        "pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.13.3?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/com.fasterxml.jackson.module/jackson-module-parameter-names@2.13.3?type=jar",
+      "dependsOn" : [
+        "pkg:maven/com.fasterxml.jackson.core/jackson-core@2.13.3?type=jar",
+        "pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.13.3?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/org.springframework.boot/spring-boot-starter-tomcat@2.7.3?type=jar",
+      "dependsOn" : [
+        "pkg:maven/jakarta.annotation/jakarta.annotation-api@1.3.5?type=jar",
+        "pkg:maven/org.apache.tomcat.embed/tomcat-embed-core@9.0.65?type=jar",
+        "pkg:maven/org.apache.tomcat.embed/tomcat-embed-el@9.0.65?type=jar",
+        "pkg:maven/org.apache.tomcat.embed/tomcat-embed-websocket@9.0.65?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/org.apache.tomcat.embed/tomcat-embed-core@9.0.65?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/org.apache.tomcat.embed/tomcat-embed-el@9.0.65?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/org.apache.tomcat.embed/tomcat-embed-websocket@9.0.65?type=jar",
+      "dependsOn" : [
+        "pkg:maven/org.apache.tomcat.embed/tomcat-embed-core@9.0.65?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/org.springframework/spring-webmvc@5.3.22?type=jar",
+      "dependsOn" : [
+        "pkg:maven/org.springframework/spring-aop@5.3.22?type=jar",
+        "pkg:maven/org.springframework/spring-beans@5.3.22?type=jar",
+        "pkg:maven/org.springframework/spring-context@5.3.22?type=jar",
+        "pkg:maven/org.springframework/spring-core@5.3.22?type=jar",
+        "pkg:maven/org.springframework/spring-expression@5.3.22?type=jar",
+        "pkg:maven/org.springframework/spring-web@5.3.22?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/org.springframework.boot/spring-boot-starter-validation@2.7.3?type=jar",
+      "dependsOn" : [
+        "pkg:maven/org.springframework.boot/spring-boot-starter@2.7.3?type=jar",
+        "pkg:maven/org.apache.tomcat.embed/tomcat-embed-el@9.0.65?type=jar",
+        "pkg:maven/org.hibernate.validator/hibernate-validator@6.2.4.Final?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/org.hibernate.validator/hibernate-validator@6.2.4.Final?type=jar",
+      "dependsOn" : [
+        "pkg:maven/jakarta.validation/jakarta.validation-api@2.0.2?type=jar",
+        "pkg:maven/org.jboss.logging/jboss-logging@3.4.3.Final?type=jar",
+        "pkg:maven/com.fasterxml/classmate@1.5.1?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/jakarta.validation/jakarta.validation-api@2.0.2?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/org.springframework.boot/spring-boot-starter-thymeleaf@2.7.3?type=jar",
+      "dependsOn" : [
+        "pkg:maven/org.springframework.boot/spring-boot-starter@2.7.3?type=jar",
+        "pkg:maven/org.thymeleaf/thymeleaf-spring5@3.0.15.RELEASE?type=jar",
+        "pkg:maven/org.thymeleaf.extras/thymeleaf-extras-java8time@3.0.4.RELEASE?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/org.thymeleaf/thymeleaf-spring5@3.0.15.RELEASE?type=jar",
+      "dependsOn" : [
+        "pkg:maven/org.thymeleaf/thymeleaf@3.0.15.RELEASE?type=jar",
+        "pkg:maven/org.slf4j/slf4j-api@1.7.36?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/org.thymeleaf/thymeleaf@3.0.15.RELEASE?type=jar",
+      "dependsOn" : [
+        "pkg:maven/org.attoparser/attoparser@2.0.5.RELEASE?type=jar",
+        "pkg:maven/org.unbescape/unbescape@1.1.6.RELEASE?type=jar",
+        "pkg:maven/org.slf4j/slf4j-api@1.7.36?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/org.attoparser/attoparser@2.0.5.RELEASE?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/org.unbescape/unbescape@1.1.6.RELEASE?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/org.thymeleaf.extras/thymeleaf-extras-java8time@3.0.4.RELEASE?type=jar",
+      "dependsOn" : [
+        "pkg:maven/org.thymeleaf/thymeleaf@3.0.15.RELEASE?type=jar",
+        "pkg:maven/org.slf4j/slf4j-api@1.7.36?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/com.h2database/h2@2.1.214?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/mysql/mysql-connector-java@8.0.30?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/org.postgresql/postgresql@42.3.6?type=jar",
+      "dependsOn" : [
+        "pkg:maven/org.checkerframework/checker-qual@3.5.0?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/org.checkerframework/checker-qual@3.5.0?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/javax.cache/cache-api@1.1.1?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/org.ehcache/ehcache@3.10.0?type=jar",
+      "dependsOn" : [
+        "pkg:maven/javax.cache/cache-api@1.1.1?type=jar",
+        "pkg:maven/org.slf4j/slf4j-api@1.7.36?type=jar",
+        "pkg:maven/org.glassfish.jaxb/jaxb-runtime@2.3.6?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/org.webjars.npm/bootstrap@5.1.3?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/org.webjars.npm/font-awesome@4.7.0?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/org.springframework.boot/spring-boot-devtools@2.7.3?type=jar",
+      "dependsOn" : [
+        "pkg:maven/org.springframework.boot/spring-boot@2.7.3?type=jar",
+        "pkg:maven/org.springframework.boot/spring-boot-autoconfigure@2.7.3?type=jar"
+      ]
+    }
+  ]
+},
+  "git-metadata": {
+"repository-url": "https://github.com/Eknathreddy09/spring-petclinic-appadvisor",
+  "commit": {
+    "sha": "1f5f924a461451c5043b1918ab14336caa2cd30c",
+	"refs": [ "HEAD","refs/heads/main","refs/remotes/origin/HEAD","refs/remotes/origin/main" ],
+	"time": 1749744365000
+  }
+},
+
+  "tools": [
+    { "name": "mvnw", "version": "3.8.1" },
+    { "name": "java", "version": "8"}
+  ],
+  "submodules": ["org.springframework.samples:spring-petclinic"]
+}
+$========= [ build-config.json ] =========
+
+

--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
   <properties>
 
     <!-- Generic properties -->
-    <java.version>1.8</java.version>
+    <java.version>11</java.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
@@ -23,7 +23,7 @@
     <webjars-bootstrap.version>5.1.3</webjars-bootstrap.version>
     <webjars-font-awesome.version>4.7.0</webjars-font-awesome.version>
 
-    <jacoco.version>0.8.7</jacoco.version>
+    <jacoco.version>0.8.13</jacoco.version>
     <nohttp-checkstyle.version>0.0.10</nohttp-checkstyle.version>
     <spring-format.version>0.0.31</spring-format.version>
 

--- a/target/.advisor/build-config.json
+++ b/target/.advisor/build-config.json
@@ -1,0 +1,6350 @@
+{
+  "sbom": {
+  "bomFormat" : "CycloneDX",
+  "specVersion" : "1.5",
+  "serialNumber" : "urn:uuid:7061251d-47b7-3ac0-930e-968cbc34f7be",
+  "version" : 1,
+  "metadata" : {
+    "timestamp" : "2025-06-12T16:08:08Z",
+    "lifecycles" : [
+      {
+        "phase" : "build"
+      }
+    ],
+    "tools" : [
+      {
+        "vendor" : "OWASP Foundation",
+        "name" : "CycloneDX Maven plugin",
+        "version" : "2.8.0",
+        "hashes" : [
+          {
+            "alg" : "MD5",
+            "content" : "76ffec6a7ddd46b2b24517411874eb99"
+          },
+          {
+            "alg" : "SHA-1",
+            "content" : "5b0d5b41975b53be4799b9621b4af0cfc41d44b6"
+          },
+          {
+            "alg" : "SHA-256",
+            "content" : "6852aa0f4e42a2db745bab80e384951a6a65b9215d041081d675780999027e81"
+          },
+          {
+            "alg" : "SHA-512",
+            "content" : "417de20fcdcb11c9713bacbd57290d8e68037fdb4553fd31b8cb08bd760ad52dc65ea88ad4be15844ad3fd5a4d3e440d2f70326f2fe1e63ec78e059c9a883f8d"
+          },
+          {
+            "alg" : "SHA-384",
+            "content" : "5eb755c6492e7a7385fa9a1e1f4517875bcb834b2df437808a37a2d6f5285df428741762305980315a63fcef1406597d"
+          },
+          {
+            "alg" : "SHA3-384",
+            "content" : "0fe16a47cf7aab0b22251dafcc39939b68e8f1778093309d8d2060b51a08df445a8b8ed5a9561669faf2e55f907c76d8"
+          },
+          {
+            "alg" : "SHA3-256",
+            "content" : "3e5a1eb5ab7d0797498862794709ff8eaaa071fe4cc9ec77f52db7e2f97ef487"
+          },
+          {
+            "alg" : "SHA3-512",
+            "content" : "59281a3e29e76270d7f44b40b5b9f05e55f1ae3ec716d80add806f360940809e3813998ac7c5758043b8e248aed73b86e37dc506cdb4cde03c16bb617d8e5a3a"
+          }
+        ]
+      }
+    ],
+    "component" : {
+      "group" : "org.springframework.samples",
+      "name" : "spring-petclinic",
+      "version" : "2.7.3",
+      "description" : "Parent pom providing dependency and plugin management for applications built with Maven",
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.springframework.samples/spring-petclinic@2.7.3?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://spring.io/projects/spring-boot/spring-petclinic"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/spring-projects/spring-boot/spring-petclinic"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.springframework.samples/spring-petclinic@2.7.3?type=jar"
+    },
+    "properties" : [
+      {
+        "name" : "maven.goal",
+        "value" : "makeAggregateBom"
+      },
+      {
+        "name" : "maven.scopes",
+        "value" : "compile,provided,runtime,system"
+      }
+    ]
+  },
+  "components" : [
+    {
+      "publisher" : "Pivotal Software, Inc.",
+      "group" : "org.springframework.boot",
+      "name" : "spring-boot-starter-actuator",
+      "version" : "2.7.3",
+      "description" : "Starter for using Spring Boot's Actuator which provides production ready features to help you monitor and manage your application",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "af3f145e2a3f130abf684c3b30d82398"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "dfc9122bab9213d6bbed1b77921ceffc0b16538f"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "ea6155624148ae58bde38e72dd14c1b8915d5c204a833ed52f5c42617a14ba5b"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "a6d1867927c91a6a88bb3432830394ad41a4f0d515d00288f715844384b1a15ecedc5495500e32e0af94a75619adbc9e9a54030792d8fe0b23990d4d721b0546"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "3c3e09ea6ba2185d1743368a53d826f3c44fd7536a8a1af3ce506a2b6fc5f3fe81c0e1281dcd9468b517c6956632a1f6"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "4e2d502ecda728e318eca54c9851c04cf64dfb0d4fb74cfd590cb11d3c7b66b2bd011e54a15526968ce8b031c8cc5115"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "65d19cf18e3d6b24971a6d295dc2dad8d3f534b70c9f318dd3228b404b6816e8"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "cfea78d22be22219b44fd8d5daaa3afb274390a183b3db6c45af4f0c8f2ee22b8616d2a48a30a0e3aafa911c86a164271f4a557a606ef5a1d1a3bea9509bdbe0"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.springframework.boot/spring-boot-starter-actuator@2.7.3?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://spring.io/projects/spring-boot"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/spring-projects/spring-boot/issues"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/spring-projects/spring-boot"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.springframework.boot/spring-boot-starter-actuator@2.7.3?type=jar"
+    },
+    {
+      "publisher" : "Pivotal Software, Inc.",
+      "group" : "org.springframework.boot",
+      "name" : "spring-boot-starter",
+      "version" : "2.7.3",
+      "description" : "Core starter, including auto-configuration support, logging and YAML",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "4108a60fa81b19d10599a42a733cceba"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "6b0c093af667bf645cd5f49372e2a2540ae2855f"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "3df6c34b9f02210a75277ee3fe2e397ecc100947cca7883f4c2856f5d47ed204"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "874e4fad0ce0a6a08365e3c2b65f774c2856959e599206e3c912edd0acb1edc5dbf6d8b6d5b32b91b282d0e16b8374ad39ed541b17a81cf403231ea958acb579"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "1589abc84b274408b90e45a20de614351eb6df2fd77426503453fd1a0ce0c9c5c90cef46bc5a8d8b3154556d73c179d3"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "f35099243c2e55a603cfd9b9e64489f7d135b51cea15fc456903cae6a9590434ab1af4782aaa5308b4c4ef294da153d3"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "d58c981424936c3a779c5bcec0fe77244354f8285746fc4a610c66072fd2379d"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "b3133f5a3080e766aacc1de0c126b122239cc8a0e06ff4c8071420e1ef94910cf7e7fb5887d1f20710e3d1594d4ce251fb325fac92f5b804f5fe3adff5d07f9f"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.springframework.boot/spring-boot-starter@2.7.3?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://spring.io/projects/spring-boot"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/spring-projects/spring-boot/issues"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/spring-projects/spring-boot"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.springframework.boot/spring-boot-starter@2.7.3?type=jar"
+    },
+    {
+      "publisher" : "Pivotal Software, Inc.",
+      "group" : "org.springframework.boot",
+      "name" : "spring-boot-starter-logging",
+      "version" : "2.7.3",
+      "description" : "Starter for logging using Logback. Default logging starter",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "87a80137cd878d906d2d4918b2e5f09b"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "a1e4a13b656182ba10b4c0c7848f91cd6f854fdf"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "ca0953f65d5b36a85b5652fb4a3a0c5bad78553932838fb097bbe4641521f2f2"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "eea041098bc7dbbb63ea0705d068cb01bbbcfa803adb787cc93d9fcbd621fc8530cdc26cbaec92b4abc57fae91b6a9b6cd6c13e4bf260f2104c5323a51eeee77"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "4f0d4e3aca18e45eb90d6c2656aad859835a03856f81cc211c35f9403da7df37ef86891b6ea7ec6987ae3b44ebc15852"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "def9c19d7520961a7ffe2b142d4ac1d978ed36617b8e6b86343123a546d93ac1d053dbc48055a697129ec33b4d83d3fc"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "fdd29b2477737d27577363bd7ef6e19b7bb5ceb7087d2d20e74f7ea1a342a1dd"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "8d562a9f022f34d3d2bcc943acc2a7070c05d0007aca2bc74ac5847db610d4632904e6bbfba2923eebe17a05c1df7f813392e5d082cecbd80a5351f1b0af87e9"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.springframework.boot/spring-boot-starter-logging@2.7.3?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://spring.io/projects/spring-boot"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/spring-projects/spring-boot/issues"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/spring-projects/spring-boot"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.springframework.boot/spring-boot-starter-logging@2.7.3?type=jar"
+    },
+    {
+      "publisher" : "QOS.ch",
+      "group" : "ch.qos.logback",
+      "name" : "logback-classic",
+      "version" : "1.2.11",
+      "description" : "logback-classic module",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "e13679004cc76ad5792f275f04884fab"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "4741689214e9d1e8408b206506cbe76d1c6a7d60"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "4d8e899621a3006c2f66e19feab002b11e6cfc5cb1854fc41f01532c00deb2aa"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "6df8b42396c5d3257f11fb19c280533aa28d66e647115816d4ebfd6a58c9b5adf0e098504772261b29435df75b86cb2b9a47f846ed45d770179c9d10f39941de"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "d480881d1a0d58c94aba0b719d56cd492147bc6481b67370dc7426ea7a81326af5b19f32d6a95fee714f37b90a5eed76"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "070647c93da744f04cc13ab3f1958c61a8b1e219fe221ed0bf251e4cc97563c64be323bfb3a9e2fd4839e33ded424b21"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "60c1dbe51066ffb3885673255a279e8894c89fe26f079180fa992478c1d9b03e"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "ce16fae69767bca975bec0d7dd0ceeb40c15cf034a4a949721c828a0f2c25cb9d619c4db3f986f6d9805d5b76d27b8926c55be5579522cd5ab3fa5e69bb68aeb"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "EPL-1.0"
+          }
+        },
+        {
+          "license" : {
+            "name" : "GNU Lesser General Public License",
+            "url" : "http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/ch.qos.logback/logback-classic@1.2.11?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "http://logback.qos.ch/logback-classic"
+        },
+        {
+          "type" : "distribution-intake",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/ceki/logback/logback-classic"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/ch.qos.logback/logback-classic@1.2.11?type=jar"
+    },
+    {
+      "publisher" : "QOS.ch",
+      "group" : "ch.qos.logback",
+      "name" : "logback-core",
+      "version" : "1.2.11",
+      "description" : "logback-core module",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "115da115b5e66ef64e774ec35af1fb1a"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "a01230df5ca5c34540cdaa3ad5efb012f1f1f792"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "6ce1e9397be8298a2e99029f55f955c6fa3cef255171c554d0b9c201cffd0159"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "86b12a74c2a822a12ba2e9a7b0db5013803f18784a3cb1201c95d5f7872a6aa8cf06d5861a5c35777a7decc7ea26df7b4388fab3b3b71aab7274527d9b339318"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "2afd896ebe6333d99e5baa553d80b7851d8ff51c06c725267e061df81bc9a878b74a65394699ae853f9738a08963aa0a"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "43d39acc5608b60d671c000bf6114f4623d3057399142abca01b0fc2381f2191479a2f0dd74f812223b66f57fa48fd9c"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "c23af1733b972e958369a2e14372fd2b306d4f552d7ae5ff6b9dfad3c14611c6"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "c7f6357d32a3b9fd82dfbd162c3a6cbe4b4909ef530e956bcd18649b2d3624eb51c5a71fee54533a9786e87cf1ccdc693f563ef6e3c6fbff7beedbd1d670f9bb"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "EPL-1.0"
+          }
+        },
+        {
+          "license" : {
+            "name" : "GNU Lesser General Public License",
+            "url" : "http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/ch.qos.logback/logback-core@1.2.11?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "http://logback.qos.ch/logback-core"
+        },
+        {
+          "type" : "distribution-intake",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/ceki/logback/logback-core"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/ch.qos.logback/logback-core@1.2.11?type=jar"
+    },
+    {
+      "publisher" : "The Apache Software Foundation",
+      "group" : "org.apache.logging.log4j",
+      "name" : "log4j-to-slf4j",
+      "version" : "2.17.2",
+      "description" : "The Apache Log4j binding between Log4j 2 API and SLF4J.",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "14b27a4266c6d71c949cb4591ee463cc"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "17dd0fae2747d9a28c67bc9534108823d2376b46"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "9bcfa5273527b950d79739d11e8f8080cfc881908fa2a946b4e891c0293094de"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "c90bbaacaabeed35f80be4d723b54234fd137413888870d6e1c1b16c067cbede57d637a18f0d25421a9c419fc55a9c388ce235077cfd6497178dfe67c5d398e8"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "c8374c05542d5a04a831a66596fe31cf385a303643e724840a70508aaa98e4870234aa8a26ac1f4fab167fe45bf34e6f"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "25c843c30137e459b94476843d8312a49d75b40d80469b1943b44a6bd2fd51f6b6f71b23d4bc559f91ae0f28763c7b0b"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "d0e8a8996e79cc881a10a55b4887436a9458625007f03b071230d1c4e96b54b6"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "6d0ec7c51ea40dee55c3c9a60ec198fe7461fba1f6b30a88b866608e83f47fb1328754b8fe33f3993f8c1ececc89c9ea83cb8b266f36fd9c1b8095946d330e2f"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.apache.logging.log4j/log4j-to-slf4j@2.17.2?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://logging.apache.org/log4j/2.x/log4j-to-slf4j/"
+        },
+        {
+          "type" : "build-system",
+          "url" : "https://ci-builds.apache.org/job/Logging/job/log4j/"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://logging.apache.org/log4j/2.x/download.html"
+        },
+        {
+          "type" : "distribution-intake",
+          "url" : "https://repository.apache.org/service/local/staging/deploy/maven2"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://issues.apache.org/jira/browse/LOG4J2"
+        },
+        {
+          "type" : "mailing-list",
+          "url" : "https://lists.apache.org/list.html?log4j-user@logging.apache.org"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://gitbox.apache.org/repos/asf?p=logging-log4j2.git/log4j-to-slf4j"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.apache.logging.log4j/log4j-to-slf4j@2.17.2?type=jar"
+    },
+    {
+      "publisher" : "The Apache Software Foundation",
+      "group" : "org.apache.logging.log4j",
+      "name" : "log4j-api",
+      "version" : "2.17.2",
+      "description" : "The Apache Log4j API",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "0c39d90e7819c92c111e447bdf786a90"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "f42d6afa111b4dec5d2aea0fe2197240749a4ea6"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "09351b5a03828f369cdcff76f4ed39e6a6fc20f24f046935d0b28ef5152f8ce4"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "8f986171ee6ca94ba8eacfc83b5b45bb87221c176076eb152715fcb4e1f351c4e9f88d56420fc02ee166ebe0b896fb52eda21355dec49302ab3e83a56b245d04"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "e4ba0afbfd91ef295e6c1c1edfa7854e216a29705b5c4b520f803697ae6badf3630c5d55e56394954988fa88e62176b4"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "ef8ecf2f848bcb18790d79b1d4e0fac0582e94f226eb8c7039d7316bd9f4c472556a4052b4a93958eb1248c7a3756433"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "bdcccb79127c28c0f42374eeac65891e7c0d02f18e1469c705e946f74cfc89db"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "14a4d4f38dc5392f378e006994780d686095e1190d476fd18efcd4211bd4dcd64b699d79c5f4351c51f2d26a3ab98b4a49745df6dbd404e3bc981797a5b8c075"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.apache.logging.log4j/log4j-api@2.17.2?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://logging.apache.org/log4j/2.x/log4j-api/"
+        },
+        {
+          "type" : "build-system",
+          "url" : "https://ci-builds.apache.org/job/Logging/job/log4j/"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://logging.apache.org/log4j/2.x/download.html"
+        },
+        {
+          "type" : "distribution-intake",
+          "url" : "https://repository.apache.org/service/local/staging/deploy/maven2"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://issues.apache.org/jira/browse/LOG4J2"
+        },
+        {
+          "type" : "mailing-list",
+          "url" : "https://lists.apache.org/list.html?log4j-user@logging.apache.org"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://gitbox.apache.org/repos/asf?p=logging-log4j2.git/log4j-api"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.apache.logging.log4j/log4j-api@2.17.2?type=jar"
+    },
+    {
+      "publisher" : "QOS.ch",
+      "group" : "org.slf4j",
+      "name" : "jul-to-slf4j",
+      "version" : "1.7.36",
+      "description" : "JUL to SLF4J bridge",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "2a3fe73e6cafe8f102facaf2dd65353f"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "ed46d81cef9c412a88caef405b58f93a678ff2ca"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "9e641fb142c5f0b0623d6222c09ea87523a41bf6bed48ac79940724010b989de"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "0bb1e7343d07d41bcfb0c1ffeb2db28cbb35e7a80a409b80042f463b082a292976f09d719e319471e31c7bab716121728a16509fd385fc6e3b400b1b214cffea"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "50e2f326fc00537a5fb3726c7c55556851b3be8b4346f522f27ddecf2fdb44adabae3197b30ccfd854c37d6734adbd8f"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "4ad0c3870852ac44530a9dcb992d947cd8708ee6f422559da41aaaa8b22d1610fb116b32d2c54df83b110b85487083bf"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "8e3f5aaaa27f618b52e610376d2a16c6f9dc8dce5e6c2bbe42131a590626aae6"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "e3da265406b5e69f02235ed7272a48f71cb8b6f0a696820e28e90fb5eafeeb311abf2a4e779b402f384c6a80470fd41116ee52a526f57040fae3b24cb3b19c01"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "MIT",
+            "url" : "https://opensource.org/licenses/MIT"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.slf4j/jul-to-slf4j@1.7.36?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "http://www.slf4j.org"
+        },
+        {
+          "type" : "distribution-intake",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/qos-ch/slf4j/jul-to-slf4j"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.slf4j/jul-to-slf4j@1.7.36?type=jar"
+    },
+    {
+      "publisher" : "Eclipse Foundation",
+      "group" : "jakarta.annotation",
+      "name" : "jakarta.annotation-api",
+      "version" : "1.3.5",
+      "description" : "Jakarta Annotations API",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "8b165cf58df5f8c2a222f637c0a07c97"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "59eb84ee0d616332ff44aba065f3888cf002cd2d"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "85fb03fc054cdf4efca8efd9b6712bbb418e1ab98241c4539c8585bbc23e1b8a"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "d1acff146c0f9ea923a9325ad4c22ba2052ec474341ab8392abab7e8abd3ca010db2400ff9b5849fc4f1fa5c0a18830eb104da07a13bd26b4f0a43d167935878"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "004a4bde333c0575f72df1cb9cf95ee0c6c7f738a6f0f723a5ec545aaa1664abeb82f01627708a1377e3136754fb7859"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "abcc5b1fbad59b3e9b6d2d6195ec11d6254f689116c534a964724b61f815cca60ba3a2c1489933403f3f78dc54fd20a6"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "3d3ef16365e7a0357d82f874fa26b2b0a146cf7bf98a351c65ef1586444fa009"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "88625a8811be514851209291344df32478b527bc7838ddee58752269bf2457ae8f4e6b6a0d0b5c18522e287ba6df1def0cb19dee2b85e01ee21f0b48ac2630d3"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "EPL-2.0"
+          }
+        },
+        {
+          "license" : {
+            "id" : "GPL-2.0-with-classpath-exception"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/jakarta.annotation/jakarta.annotation-api@1.3.5?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://projects.eclipse.org/projects/ee4j.ca"
+        },
+        {
+          "type" : "distribution-intake",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/eclipse-ee4j/common-annotations-api/issues"
+        },
+        {
+          "type" : "mailing-list",
+          "url" : "https://dev.eclipse.org/mhonarc/lists/ca-dev"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/eclipse-ee4j/common-annotations-api"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/jakarta.annotation/jakarta.annotation-api@1.3.5?type=jar"
+    },
+    {
+      "group" : "org.yaml",
+      "name" : "snakeyaml",
+      "version" : "1.30",
+      "description" : "YAML 1.1 parser and emitter for Java",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "ba063b8ef3a8bfd591a1b56451166b14"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "8fde7fe2586328ac3c68db92045e1c8759125000"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "f43a4e40a946b8cdfd0321bc1c9a839bc3f119c57e4ca84fb87c367f51c8b2b3"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "b00f52326cae804d0dbb48c0ed7f3a98cdebbce9b145f685c616e4049b65183a18e98ca29b7b0275971f9ece52138d0015bb9771902532084cb2cc07a264cfc6"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "aa4f7b90b3a2a83274664f78ca54b523e26ea2f96750c336a8802a6f68fc0842e3e8d36ce4f7e277e7d959aba3bb3246"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "d3cd269127dca6042237f66cf3c3557f87f395d0286712e74da908d11ffb5d4ee7c4960e29e61db346a8376e515d59af"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "4a3c20ddae5c74b381476c491716e01f847e76e28fe82dc46819e9ef122c70fa"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "d1e848c74efd4dd2ba5d4878c0f9df6144926b1d413f44ba2881614cc557a18479eb74c8f1c3392375cc166c94acf2adb7f211f902a7e5acfd7b2966bec70f26"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.yaml/snakeyaml@1.30?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://bitbucket.org/snakeyaml/snakeyaml"
+        },
+        {
+          "type" : "distribution-intake",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://bitbucket.org/snakeyaml/snakeyaml/issues"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://bitbucket.org/snakeyaml/snakeyaml/src"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.yaml/snakeyaml@1.30?type=jar"
+    },
+    {
+      "publisher" : "Pivotal Software, Inc.",
+      "group" : "org.springframework.boot",
+      "name" : "spring-boot-actuator-autoconfigure",
+      "version" : "2.7.3",
+      "description" : "Spring Boot Actuator AutoConfigure",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "194dadf731affb1fea9c1299d2d1e2fa"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "9d32a56377308bce1b02e3fe6832400bfbede14d"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "6c9294ea2537d289e4a0a67ce7af6e36ab3c14f294da2c5fa324bd2a3f654d7c"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "bf67b85d669ac69fc15bb0a1b93dec451673e0949df6bcadfa06352758dc0b3160a34b1202be816d5a9bb212b2054f4f6b61d817981c1fb47a826461bae804f1"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "e2575c7a01e04ad81c2b4f8555155c6b5e639c487ba49be9fb112407e38deffe4288d9f077badb35a101e7dc45ed7242"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "1d280253f73c25dd7697ea3d554b8b48f3e6025b791ed18813bb0b51dfd25a4297ffa0bc9065800194e08111da35fd8b"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "d314377d890fc0bb40e38085e01fcb904d86ba4b30a52e14f2ae0ef08ee0f121"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "3f2bf176f8512bb8b36b0caadcdcb9ee59c19fad38b4d3e48de0f7b61caf4b7f89b741ca4f1ac599c0a8b7831eae277eb36bd64d535655157f939c73acc8d0d9"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.springframework.boot/spring-boot-actuator-autoconfigure@2.7.3?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://spring.io/projects/spring-boot"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/spring-projects/spring-boot/issues"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/spring-projects/spring-boot"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.springframework.boot/spring-boot-actuator-autoconfigure@2.7.3?type=jar"
+    },
+    {
+      "publisher" : "Pivotal Software, Inc.",
+      "group" : "org.springframework.boot",
+      "name" : "spring-boot-actuator",
+      "version" : "2.7.3",
+      "description" : "Spring Boot Actuator",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "7344030215ef49cf258c5b7017cfb386"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "a991796db5d89f9014d87a307208badffc40bcca"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "4c9cdf875693d16e4b70d5fea86533374b64bbf66ad2a8e6ca9dbb0a36b71b95"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "a52a632b89f4c59e4ffe21bfb99dda7f9e9f41545505d51ac019821ee3d1541c6379d0a2e7f5e81550f9815e35fbd25c19532a300b8bc11c04d1c1a90b6b9538"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "0d886200dff99bee5a88d901fc04bffa35a6325b9644c7cb4d1645638aed23583e36f605e6e2fad8d715d806ff29df1b"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "b721d26f4993c86297833d0f6d16d923f7dc256aabf77727819dbc8c032377f6cce77ff384942185f68eae26d507782f"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "001e04b2f80ebdfc7716f20d3b4d0f3f267a6c21aa7af4bc9f83ad6886726474"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "4db23322692257031154a4a4a6d66704ca10918a071c4d20e679c411719a5b7ed7169642994e4a8fe3eae4e55037ebac3de27dedec579eab0536e97f44cf539e"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.springframework.boot/spring-boot-actuator@2.7.3?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://spring.io/projects/spring-boot"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/spring-projects/spring-boot/issues"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/spring-projects/spring-boot"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.springframework.boot/spring-boot-actuator@2.7.3?type=jar"
+    },
+    {
+      "publisher" : "FasterXML",
+      "group" : "com.fasterxml.jackson.core",
+      "name" : "jackson-databind",
+      "version" : "2.13.3",
+      "description" : "General data-binding functionality for Jackson: works on core streaming API",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "e35e2adf33b2eed8e9f538a911244175"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "56deb9ea2c93a7a556b3afbedd616d342963464e"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "6444bf08d8cd4629740afc3db1276938f494728deb663ce585c4e91f6b45eb84"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "dd6daeb7481bab4641adf71552774dd143039dc856aa6e3e5805c1964fecc69eb18a2fd8201e16ebebb92549edb7f10d1f9a50391ed9a120f867b675a6d4d4ff"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "38a8c81bc7a37315428697ab761f4c12b409046247414532fc68e37bb2a70e0d0a50b555dd20a251c6f63a85dfe536bc"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "27936164e28773f942663edb22e1022bcf061ab1b4afcb45e6705b30a4e17cd668066edc094a8bd8bc44b82852313909"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "e3f1bca51b619ada05e6a4f88ff37d65625e9fb9e5a4b3c017834c6594c964bb"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "cc93eb45e2c1997db9b78b38db68f2648493c1ea79932ad076dfcbc5e5edfd8015798ff5d99a9f06f9e7dca745c53406b8954ec1ffc626a61ece429c30a06f47"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.13.3?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "http://github.com/FasterXML/jackson"
+        },
+        {
+          "type" : "distribution-intake",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/FasterXML/jackson-databind/issues"
+        },
+        {
+          "type" : "vcs",
+          "url" : "http://github.com/FasterXML/jackson-databind"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.13.3?type=jar"
+    },
+    {
+      "publisher" : "FasterXML",
+      "group" : "com.fasterxml.jackson.core",
+      "name" : "jackson-annotations",
+      "version" : "2.13.3",
+      "description" : "Core annotations used for value types, used by Jackson data binding package.",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "3fb8ee542a62a113fa7474fe88bb97e8"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "7198b3aac15285a49e218e08441c5f70af00fc51"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "5326a6fbcde7cf8817f36c254101cd45f6acea4258518cd3c80ee5b89f4e4b9b"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "7f89b142068879b5fd96e4cb947313b3b39c1dbead43480307360a212fdb5347046b14fbc9b94c480034a4826fdd2a821686ebd121d774d55795326eaa1c95fd"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "245c29f5dff5e7677c7f614df69de1072dbb56717fe88890128dfd6479994bb9a81a9917d41a2831a9a96e6d12aa3bb1"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "14086ba58917fddf8b86e16db4a865d6550c3368e7c4ac11f14a29e60165c1a85cece76c03fa046ff6482af4c96618bb"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "69aa8638b7dee54ed7d676e90054977ffedc0e7e19acd82ae6a2ca28ed706b03"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "74121eb8b75529ebf01a8af81348efa889a9d13914620c95c23548a4dc42babac9f33556b0f668c66610f95db5854ced45fc5c0518147ec233af37213aa9c858"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/com.fasterxml.jackson.core/jackson-annotations@2.13.3?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "http://github.com/FasterXML/jackson"
+        },
+        {
+          "type" : "distribution-intake",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/FasterXML/jackson-annotations/issues"
+        },
+        {
+          "type" : "vcs",
+          "url" : "http://github.com/FasterXML/jackson-annotations"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/com.fasterxml.jackson.core/jackson-annotations@2.13.3?type=jar"
+    },
+    {
+      "publisher" : "FasterXML",
+      "group" : "com.fasterxml.jackson.core",
+      "name" : "jackson-core",
+      "version" : "2.13.3",
+      "description" : "Core Jackson processing abstractions (aka Streaming API), implementation for JSON",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "9a6679e6a2f7d601a9f212576fda550c"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "a27014716e4421684416e5fa83d896ddb87002da"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "ab119a8ea3cc69472ebc0e870b849bfbbe536ad57d613dc38453ccd592ca6a3d"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "d5337db908b2c56dcb911e3d1a5f671456c13f254fe8d2a620823bc15b2db6aaa8325a86b436b5d181f2584b533158fd14d140b98305ac252f8dfd9a627da859"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "7b96a15f15eb9a44795c632313503677e0e65615d31922861138ee059defb1db31dbd98144a6474c25fa69de1c60f7d7"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "da78b678f4ebdbc9f61efd9475b67d35dc7ff5f2aa80bedaed8e9fbeecc2a96f2c793009abd1e4d5f27ae8fd2a81ad7c"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "4511d609261102f213a9704d71541f813360699b81c44ec795a8fb88bd087daf"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "e0d26e27d5d8920a856c7e8be48236bafae837994da1f8daced1078a1acde2ff1007e2849c9b007365e67541e1e881a18c1f7c66ed11fbc9fcdb91b8ea69dffa"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/com.fasterxml.jackson.core/jackson-core@2.13.3?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://github.com/FasterXML/jackson-core"
+        },
+        {
+          "type" : "distribution-intake",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/FasterXML/jackson-core/issues"
+        },
+        {
+          "type" : "vcs",
+          "url" : "http://github.com/FasterXML/jackson-core"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/com.fasterxml.jackson.core/jackson-core@2.13.3?type=jar"
+    },
+    {
+      "publisher" : "FasterXML",
+      "group" : "com.fasterxml.jackson.datatype",
+      "name" : "jackson-datatype-jsr310",
+      "version" : "2.13.3",
+      "description" : "Add-on module to support JSR-310 (Java 8 Date & Time API) data types.",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "2b0c7790f2e820c5c9e4a9737097d256"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "ad2f4c61aeb9e2a8bb5e4a3ed782cfddec52d972"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "5a2489b4c08ed7a7f132b43789b604e9186695b17f04f3fbc935a62c415b34a3"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "826e480799a2a6ee0fb7f34a29aea44adf24ff02fea1b3943d3761272c0f76ba52e12413905e3a903b0aa904718b09befc5c63543c604addbbaaac4eb15d16da"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "7ab0a6de658dd40f98373f8859b3b36534593075b97e83ebde9f51e97df2cb97aeb633c7ccce6a41beba0918d97f81e9"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "2bb1b2a023e60263db0aeb47bfeabb54d71df66cd6eb4bf7ed6919d6fb33bc7d21d673b9f49cadbc4586e2caad36bfa4"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "2f3c426c2e4f120d54563e463a23ecdd550751e85282d78457fd23cb43beb87b"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "9b3f84921b04a3bd44257a31990dee3f00e887fbfeab1a8e8aae84629bf465d45ccbd869ba6b074bd6024b7f654d23079acefb2ff66d4ee321969574291a9f2c"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/com.fasterxml.jackson.datatype/jackson-datatype-jsr310@2.13.3?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://github.com/FasterXML/jackson-modules-java8/jackson-datatype-jsr310"
+        },
+        {
+          "type" : "distribution-intake",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/FasterXML/jackson-modules-java8/issues"
+        },
+        {
+          "type" : "vcs",
+          "url" : "http://github.com/FasterXML/jackson-modules-java8/jackson-datatype-jsr310"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/com.fasterxml.jackson.datatype/jackson-datatype-jsr310@2.13.3?type=jar"
+    },
+    {
+      "group" : "io.micrometer",
+      "name" : "micrometer-core",
+      "version" : "1.9.3",
+      "description" : "Core module of Micrometer containing instrumentation API and implementation",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "f12d64e8e660e137a4b771967e22e375"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "5b3bd8971b0f687c7f820d2b0b631fa97850ed94"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "aba15a90750823a41fc121452b250483ea10c2b8991b3e3ea3ac0ffe291025dc"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "185628c937f092a66e3722f07decb5fcb53112bbbf90365813d3266e77933b334427408d9d52904dd1ca567a6ef1c27a6dde7099ca9514f61a77837db785d146"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "49da5e0b4de50a7554af9f50dedd80446e14e615e8f515b289919cd374c71c90ef8ffe12ce681ed3d0fe7681acefb78e"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "eeb5452b45eb04188f4ed4fba00cb7df4de5ff2bd95cd8ecbc5f9d3a022096d8cc5da520aaf4d8d65abc54f6c1b85e05"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "b96938630e528a02c948ff31e84b1bf55026b68b971f3aa356ea0560348567ad"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "6eb74036d47a8cb8cf7262346693d6a49563efe8f09eb0fbeb12e20faf14977f6aea0498986b9f4ffa6effc16bb228cc4348e37fd59bb8cb2fd0ea0531b0ab38"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/io.micrometer/micrometer-core@1.9.3?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://github.com/micrometer-metrics/micrometer"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/io.micrometer/micrometer-core@1.9.3?type=jar"
+    },
+    {
+      "group" : "org.hdrhistogram",
+      "name" : "HdrHistogram",
+      "version" : "2.1.12",
+      "description" : "HdrHistogram supports the recording and analyzing sampled data value counts across a configurable integer value range with configurable value precision within the range. Value precision is expressed as the number of significant digits in the value recording, and provides control over value quantization behavior across the value range and the subsequent value resolution at any given level.",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "4b1acf3448b750cb485da7e37384fcd8"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "6eb7552156e0d517ae80cc2247be1427c8d90452"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "9b47fbae444feaac4b7e04f0ea294569e4bc282bc69d8c2ce2ac3f23577281e2"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "b03b7270eb7962c88324858f94313adb3a53876f1e11568a78a5b7e00a9419e4d7ab8774747427bff6974b971b6dfc47a127fca11cb30eaf7d83b716e09b1a0d"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "06977d680dafd803d32441994474e598384a584411a67c95ab4a64698c9e4cbd613e0119b54685cea275b507a0a6f362"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "b5ccb4d39bf7cc8ccc33f0f8fcbab0a63c99a94feda840b5d80fc3ae061127f1475cfb869b060933783a1f2eafb103a1"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "ef2113f27862af1d24d90c2028fc566902720248468d3c0f2f1807cc86918882"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "4fca2f75bdfd3f2ac40dc227ae2ef0272142802b1546d4f5edf9155eaeed84eff07b0c3a978291a1df096ec94724b0defb045365e6a51acfdd5da68d72c5a8eb"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "CC0-1.0"
+          }
+        },
+        {
+          "license" : {
+            "id" : "BSD-2-Clause",
+            "url" : "https://opensource.org/licenses/BSD-2-Clause"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.hdrhistogram/HdrHistogram@2.1.12?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "http://hdrhistogram.github.io/HdrHistogram/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/HdrHistogram/HdrHistogram/issues"
+        },
+        {
+          "type" : "vcs",
+          "url" : "scm:git:git://github.com/HdrHistogram/HdrHistogram.git"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.hdrhistogram/HdrHistogram@2.1.12?type=jar"
+    },
+    {
+      "group" : "org.latencyutils",
+      "name" : "LatencyUtils",
+      "version" : "2.0.3",
+      "description" : "LatencyUtils is a package that provides latency recording and reporting utilities.",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "2ad12e1ef7614cecfb0483fa9ac6da73"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "769c0b82cb2421c8256300e907298a9410a2a3d3"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "a32a9ffa06b2f4e01c5360f8f9df7bc5d9454a5d373cd8f361347fa5a57165ec"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "bb81a42498c65389366205f4e07cee336920e2f05cc0daae213f2784b1d0ce9a908b038daec20478f23eb00b2bf704f96c5b00f63c99615193ab2a3cc4a9f890"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "16ca4640dc9d848e6c6d15441897e1b5a9f27f34207b0bb456dd54d8f267b73b348092e548e78634144de44ba3515205"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "406c2b5c6f64b0c090568e479b5e6136a04a4e77f8eea65d32b4e2b01deebcdf6a0a851240cdb740c25b5a5e61e6c179"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "50ae828358301033542fd7c412e86ee318d5451f89a182e2a679aaf18099d26d"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "456c337b9fb385579aae707409ed6a04d08e5fc87b1a46733dca617c22c625bf253dc4747e0cdbf5e7d8b48102d2938cb482b6b688a79aab645a7459c592258f"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "CC0-1.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.latencyutils/LatencyUtils@2.0.3?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "http://latencyutils.github.io/LatencyUtils/"
+        },
+        {
+          "type" : "distribution-intake",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/LatencyUtils/LatencyUtils/issues"
+        },
+        {
+          "type" : "vcs",
+          "url" : "scm:git:git://github.com/LatencyUtils/LatencyUtils.git"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.latencyutils/LatencyUtils@2.0.3?type=jar"
+    },
+    {
+      "publisher" : "Pivotal Software, Inc.",
+      "group" : "org.springframework.boot",
+      "name" : "spring-boot-starter-cache",
+      "version" : "2.7.3",
+      "description" : "Starter for using Spring Framework's caching support",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "ff11940766f88179cae0cf5836179d4f"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "1484c8f477b7a7d27b50810c1685ed3e21564a1b"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "8283c804a71bc6f010cf1acbf76a642cb0f7fdc46d7deced0a3f5251e3feede6"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "8457800afee02b89048332e2cec06540e810828e963e1088b5f7df3d637a99ac3997293d74b821a150942b96ceb29d7dd99ffeb855ea9a870e1a19585df0d961"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "1f59a6f88b361e371057a4d3ef582de52d80710ddbe08ee0cd92d0d08ac56a7ebdc6422c649a836b305b22e2e30cc94b"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "16529e06bc8534c4d37f2f53a25ed2d85cd511b10a0d860176ace53e54c9b1ee3ff33a147c8d53f74954ad5abb997870"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "dad4baed1981432b9b7a4b743a93bef1a80dbc81efa1b0d5929a4a3328a63a9b"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "334721932a5fa661df781a4f023a282bc3a32df60a03b29ecfbb29e12f6032dd8786cc93071f3f77d18ccca0c7bd830ca5f0d82cf23bb9e2eb939226fa205be9"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.springframework.boot/spring-boot-starter-cache@2.7.3?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://spring.io/projects/spring-boot"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/spring-projects/spring-boot/issues"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/spring-projects/spring-boot"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.springframework.boot/spring-boot-starter-cache@2.7.3?type=jar"
+    },
+    {
+      "publisher" : "Spring IO",
+      "group" : "org.springframework",
+      "name" : "spring-context-support",
+      "version" : "5.3.22",
+      "description" : "Spring Context Support",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "454eb9b0d7a6f5cdbdb72f88d4b2ae88"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "3276aa68e9bc453063fc19d81d780cb05d6cae59"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "752bcb6868ca06a5fe5ea42bac34f8b029acb3f5c0e4bb8fce20d3a1b17ac28f"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "28c628bb6dd6992034b3598696879bcc64c2e0efe54c5ee5dc1351f15553867d0ed17b1568674fc8976de580451b0ea2bacca63241f5eca8e26495e7450ea3db"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "fec1f0050e3015e2c3e101dad9b67f1ecff93a276660286b87cabbfc4588519c188c31addb0d3609770d91d124de2004"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "476dcad94b4f57322c7f775c036641a16877975fcc7d1f96c67b8fcf3f383fa47c83e3527b5439b3c254ae64a7eae0fd"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "f3ab36ad9f73ceaf36aeb5a995babba46df96be78762bbc27ba141f76368c8cb"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "3bef19a528792ec96f4c3aa54d77ed9d80addf6a19356fad3b61a72dc742e1af82d3625c10937cc486d8b12101ee273c57e79628467e59bb91b03a4911aa5b33"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.springframework/spring-context-support@5.3.22?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://github.com/spring-projects/spring-framework"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/spring-projects/spring-framework/issues"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/spring-projects/spring-framework"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.springframework/spring-context-support@5.3.22?type=jar"
+    },
+    {
+      "publisher" : "Spring IO",
+      "group" : "org.springframework",
+      "name" : "spring-beans",
+      "version" : "5.3.22",
+      "description" : "Spring Beans",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "254c6d03b5b6164328329a188267291f"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "866c2022b5fef05b1702f4a07cfa5598660ce08a"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "4adff173a6f68ffc5a5333c8c8a37d10740b0cc124f9aafaed88a3a8ca431ca4"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "c7ae00ed34ac16fe8ae27c055896b9c2bd24ad61a08d49d25830efcb09bc5057b77bf21481ceebe63ee6f2fb70e067ea4fa4f5c926d1c1ecd396ff67a9bad14e"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "df7ed3d3e9c43ab019937b0a82f25f69cd48fbfc00cce90f41ef35c2a54aa0a68acfd891fb341b67ceba6d12c265abc1"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "e1927bdf3720a6dd80996b09560de44fadefdef40d066c671ac544f20e3b80bbeb25984ebda4fb4184771f1e84a39ff9"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "e3b45a00cae7db372ea1895d1c8d69a7d972e6864d005ab599b7147e86652f6e"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "0006ac720888aeef001f8ec6f4034e6143c80517f00bfba4106f802edaed815ec75e27a5c0138b50f992e7c1437496f66b002507f15fef9e1e504ee6c8ec9a27"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.springframework/spring-beans@5.3.22?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://github.com/spring-projects/spring-framework"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/spring-projects/spring-framework/issues"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/spring-projects/spring-framework"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.springframework/spring-beans@5.3.22?type=jar"
+    },
+    {
+      "publisher" : "Spring IO",
+      "group" : "org.springframework",
+      "name" : "spring-context",
+      "version" : "5.3.22",
+      "description" : "Spring Context",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "3b00971f0b99194b13d5762ca319b9c5"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "fdd59bb4795c7a399e95ec4a5c8b91103e3189fd"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "e7f9c4727c98aaf02542056f1c2c504dcdb4478f75c4baeb81ab15059b7552c5"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "007ddf6f0a88e20f336dacefc05cae15e0f0eb4a87baaef9232a9238c81168532e80850c0d02ef54554bd9fc8d22fd6f2ad977a6733b76c2a090fa8baa47d6a8"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "ae7c7ffe588d5e7bd29d5f5d1e75b11ad4488af3a420663fa206c281d2b3891d75bc4a1940e8d7e9b6ec4186502fc565"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "f29f84ff386cdc2dab5a26ea2bb21fbd753bfccf4e84ed16402ce1e2c6ec7b80fde982c5642c4d73099e919fa36579b0"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "c8a80d2dbfdbdb0e22cab06df80ce1ef88e7e5def7ab6b1819778a891dfd886e"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "a806426d7acd4ae652262579aae31d85c348e48ae3da9fc69c00de12bb121a73a0de9ce4f24681d629e557b54432df51caef0377b7e5762e5937da01a920d088"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.springframework/spring-context@5.3.22?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://github.com/spring-projects/spring-framework"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/spring-projects/spring-framework/issues"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/spring-projects/spring-framework"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.springframework/spring-context@5.3.22?type=jar"
+    },
+    {
+      "publisher" : "Pivotal Software, Inc.",
+      "group" : "org.springframework.boot",
+      "name" : "spring-boot-starter-data-jpa",
+      "version" : "2.7.3",
+      "description" : "Starter for using Spring Data JPA with Hibernate",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "5f79d2d0132abad21b96371b310b3c5d"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "23f7118584200cf9edd43140dc6252679047bee0"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "511eb0516e3f26c76fa0a7f6831d3638681b00d782c797034fdd205fc399fdd5"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "c511ebe36644135469b4b2956087459523434f1dc4631a3ee6b26ab216caaa72a247b8ebc2f36195a74476d19c4fa5aaedd327c729e216abbf81e3b5d2280f97"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "b3d4cd1139b26401bf4635a3ca730b45b5d36afeb17aac3f2c317be838f92c13f4c4f6ba5fd31934a5b3afa249b3701d"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "30bf86ddd1c706025d2a22346d98b4ae698f42f2b9131a2be69444b7dcd0c1bc149c3270fc2c4452624287f2f13e18d0"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "84ce5b1a1bff9eda9ea13cf5bb2e03df7d066c887b65e5bc934a82799302f149"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "0033bc7a315f31707584cdf1f9ee37505172f11d3d7bf69e6bb55251fb9a5182951dd6cffd24285153341a0a72b45f79335e7a1b626ca4bc7c14fe2ff9ae7765"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.springframework.boot/spring-boot-starter-data-jpa@2.7.3?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://spring.io/projects/spring-boot"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/spring-projects/spring-boot/issues"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/spring-projects/spring-boot"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.springframework.boot/spring-boot-starter-data-jpa@2.7.3?type=jar"
+    },
+    {
+      "publisher" : "Pivotal Software, Inc.",
+      "group" : "org.springframework.boot",
+      "name" : "spring-boot-starter-aop",
+      "version" : "2.7.3",
+      "description" : "Starter for aspect-oriented programming with Spring AOP and AspectJ",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "116bd0d65ac976dd52a3018e88a5c871"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "b2806bdfae4cff6b82a174a68984a4cedd2d83f5"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "a4d54afee8860a0ee0c437d5757fc9b47c71a5a0aa3925e585f981d79f73e943"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "acaee6dbac69818c329bef27b7fbc8cded7a3a9fb9b389700c2a83f0bf5554820b035afa7a3836b8d417e37042be36d5b65425f8a24cd68ed6c6d1341e8475a8"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "bbc2d573cdb61865f176b4220246ed6a490bca333cde731143143314dde5718b2f3710ee3575c759651706831dfbe685"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "313e0e3e397fc8a5f20bff44d097375aa11733bb1b14c8fd4f4762bf4ddc4901098f93c66604e93bfe7355543322a8a2"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "60f99a14c20c0bd35a2e897efae603944682191d5882acb2afb3535ca31ad707"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "c81771dcc508f80dc3e9fd6a87487874c27142f77ed63fdbaeea3f20378e1020098e418be8cf008f7f9023b39f94061dc8dccef31e21ce2bae772ec87bacd030"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.springframework.boot/spring-boot-starter-aop@2.7.3?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://spring.io/projects/spring-boot"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/spring-projects/spring-boot/issues"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/spring-projects/spring-boot"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.springframework.boot/spring-boot-starter-aop@2.7.3?type=jar"
+    },
+    {
+      "publisher" : "Spring IO",
+      "group" : "org.springframework",
+      "name" : "spring-aop",
+      "version" : "5.3.22",
+      "description" : "Spring AOP",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "8f59cdaf80f1836a9631b3e3c8513cb4"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "2f9f00efbff8432f145ccffeb93e6a1819bac362"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "52c0efeaa4528e30b805bbd3d908281d8488e487cd2a45d8e4d7b591e6b08e77"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "5e7be423124c37351400833fe713c0ed483815f0b52f25f2cb9bf8980214bdbb9fb982680d26f0ec0b5fc2562636d7bcb61fd537f00533469f48d942d827d9f5"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "b43083391588b48f9b63acbb9a89a45f0a0aec3d18e37cbb299093adc73228f15290c90948930a0d62ea42030ebc102f"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "fff1ebcca8aab16ee4247548e54aa7de962af72ea2e93878adf5cada697eca79597dfcff847c881c15d6a76514d97d92"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "11f31d85aee8939a9f877cee143914d5f0e6e8e7644e16334bac6ece4eb5481c"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "e0132069cd4a02fab061f100ddad98b8a3c0bc7be87d3c970d39a4bdbdbaf74e93ad8091b4fa8fbfa6d4165e9b2f4f2738c8a5a470870cb2e9fed079d913159c"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.springframework/spring-aop@5.3.22?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://github.com/spring-projects/spring-framework"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/spring-projects/spring-framework/issues"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/spring-projects/spring-framework"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.springframework/spring-aop@5.3.22?type=jar"
+    },
+    {
+      "group" : "org.aspectj",
+      "name" : "aspectjweaver",
+      "version" : "1.9.7",
+      "description" : "The AspectJ weaver applies aspects to Java classes. It can be used as a Java agent in order to apply load-time weaving (LTW) during class-loading and also contains the AspectJ runtime classes.",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "a4d97c5a2f94b8b5d132761a769e5eeb"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "158f5c255cd3e4408e795b79f7c3fbae9b53b7ca"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "1b448d82bd0f8a8c1842506e6c7edb95ff1a1275ce39f766e7884122b866fe5d"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "490fcf238486848e27cbed45fd437613193c9e89748a0818fb532aed5c213aab2624d148ed9fd58080c6934da5f7ec12c64e40b64bb46d16e361eb404393c5ba"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "4d3b13d7e7ab437410226974ad3acebc8c663b21d9ccad6d70b5adede33bc4033858e8b303c7263a8e17c073c354b87b"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "0d56981fa691d1d79f39aa65dc091def5fb106f65d5d1b0836a7279b95195961c5a49f07979cda49e35768276a30477d"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "e10b7535b50a0017f062b7eb71f1f1b301beadfe474d050f7100996797a8640c"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "a77467b7b04410e7eb33214e84b4061f3e7112eb4c29a2c826691bdc0af6136c7a78789ae685273e9e69cfb40e674b64ecb31d1e516a8b5d79afefb13f57ffa1"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "EPL-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.aspectj/aspectjweaver@1.9.7?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://www.eclipse.org/aspectj/"
+        },
+        {
+          "type" : "distribution-intake",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/eclipse/org.aspectj"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.aspectj/aspectjweaver@1.9.7?type=jar"
+    },
+    {
+      "publisher" : "Pivotal Software, Inc.",
+      "group" : "org.springframework.boot",
+      "name" : "spring-boot-starter-jdbc",
+      "version" : "2.7.3",
+      "description" : "Starter for using JDBC with the HikariCP connection pool",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "1c9aaf8e52bdfc883ab2797fc83355d9"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "c5cfc6efad06811d5dd916e86c97989b08575b31"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "8e8d6c65390a835b9c0a529d702c9508c877e52d526f709932be6963f2a269ea"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "44ceff94410acf1f6664a93e21f2fdac1168745f85850624065f713a514fa99e4b8c6e7f958b0b1a81b89f81e2b6660cfb0fa8367fbea1ce5031cf820fd289ae"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "fba77727bae7dd0cc74f45f77e32b391d25f65feff9bab8d26b7fa0446595752c72d479c5beab5e8bface1d3d2163961"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "72e7b5904e285e52e296a7bba3540765cdc6e16eea9573528e38bedf2a692dfeddd0b54a27a3e8d5da3d2468bb13afd3"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "efa71e0df44854a38214bf89e88356d2f9623b3824c04329e14c2ef30dcac9c0"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "8c657307459cb58654933852c0f8755fb4446e3c0866739363517a0df2ae870d339c5fee02621b6a0743a19f2057cc6b7f2ce6250bbfe186ab64002e9fbdc19a"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.springframework.boot/spring-boot-starter-jdbc@2.7.3?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://spring.io/projects/spring-boot"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/spring-projects/spring-boot/issues"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/spring-projects/spring-boot"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.springframework.boot/spring-boot-starter-jdbc@2.7.3?type=jar"
+    },
+    {
+      "publisher" : "Zaxxer.com",
+      "group" : "com.zaxxer",
+      "name" : "HikariCP",
+      "version" : "4.0.3",
+      "description" : "Ultimate JDBC Connection Pool",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "e725642926105cd1bbf4ad7fdff5d5a9"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "107cbdf0db6780a065f895ae9d8fbf3bb0e1c21f"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "7c024aeff1c1063576d74453513f9de6447d8e624d17f8e27f30a2e97688c6c9"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "34a9ee96c51ae070634cd0b642cad3c4c54b9d2ab7f1714f59dad805512ae27c9c69b8be83da473689f55474c4e2874c93e727f9f31d3bfc9b80ec37aeb68898"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "9c49efde42b89a8cd2b119d666076bc9d532c4a835c640b77d8a5858d3325f9ba99f8cd19cd21b9df4f386d1c21855ae"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "ccea43e68e6dcf0426c271640abf132575a9e28b439ac968b5608e3d04d7ec80dd948d33c474e31fb18bab9b80959c2b"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "163e0d75894a0a4c2d36f4a992449e2dfd71bf495f5789813cd333ad1b571fc5"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "bc20907f677b6fceaf8f81361d5a7e0099799561af550a2a49dfed531a3b8ee29f35ecc2c4419cd8eef9e25a147a2cf88cfb7ffc9218b8b35b0e0524caf56d8d"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/com.zaxxer/HikariCP@4.0.3?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://github.com/brettwooldridge/HikariCP"
+        },
+        {
+          "type" : "distribution-intake",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/com.zaxxer/HikariCP@4.0.3?type=jar"
+    },
+    {
+      "publisher" : "Spring IO",
+      "group" : "org.springframework",
+      "name" : "spring-jdbc",
+      "version" : "5.3.22",
+      "description" : "Spring JDBC",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "929ad2882685e0d809e59a0aa194a3a5"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "d50fc708ef9bade1d3fb64d529b8ff8cd5b625ba"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "a7fc8bf8bdc74dc5bffd9898844409afde38a88421ff45123f2147be1c2c7099"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "d1cd08794f203dc6689ee934b93bbadcebc2bf1defbde53b612618124e892620ad1aa1efc514b50770e69d03937ca25d61d0d294207ac31fe65774bf343ab669"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "743d9b61a991c86c0c86fd5cef0e84c37487c20b7dd07b2c329548d103858c74131efb3d72591ea20cd00c759b6b3094"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "a1bdda275b42099583ba071f705d08db625ad597cd1e715483af7ec8575fa8d1061cdca0a243b8b42aad3330deacd7b6"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "b64a2211cc71eefa26dc504e715de50910b14f98f1c9420a938cb5dced7f7347"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "8aaa08e47e02e0caca26bd036c2a0f51b75fe05e06ad9a9c5d41df65626ecbfaf68e40b5cd01abd3593ad3f9326e1ec3bb5eeb6f820e3af9e97e4b5aed367f5a"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.springframework/spring-jdbc@5.3.22?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://github.com/spring-projects/spring-framework"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/spring-projects/spring-framework/issues"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/spring-projects/spring-framework"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.springframework/spring-jdbc@5.3.22?type=jar"
+    },
+    {
+      "publisher" : "EE4J Community",
+      "group" : "jakarta.transaction",
+      "name" : "jakarta.transaction-api",
+      "version" : "1.3.3",
+      "description" : "Jakarta Transactions",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "cc45726045cc9a0728f803f9db4c90c4"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "c4179d48720a1e87202115fbed6089bdc4195405"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "0b02a194dd04ee2e192dc9da9579e10955dd6e8ac707adfc91d92f119b0e67ab"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "764ade8ba807682dcd1ec7382c35275f3d8ab09a03d5b45c48e732501190e2738269080aaf28aa8dd656c11ee84bfb7dae6953dd2768f2acecd3a8cf0ca4961e"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "63adeb3c5eb24ad0147377436b6e3208d5e97c0e800e0e1e4cb3ba92699f1b06034c2ba00e3689aa8f909ee96c432db0"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "dd0a253f45dac003d40ebeed7f38b0850ff4b08941d55db5b3bbf4c936f94062d23799729ff718c54a565de2482bfd3d"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "d47afbaf1daba46c7aa107bf1b476857523738370309394958f96a2105686684"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "1b744b2d939a8d0a2bbd0be29c717af4a5e2374ca26fbb95a16df03aa55d2aa092e9314f20d5b080f02030ae1b70e4904ef0f8e1509680b9001153cdb7bc1934"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "EPL-2.0"
+          }
+        },
+        {
+          "license" : {
+            "id" : "GPL-2.0-with-classpath-exception"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/jakarta.transaction/jakarta.transaction-api@1.3.3?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://projects.eclipse.org/projects/ee4j.jta"
+        },
+        {
+          "type" : "distribution-intake",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/eclipse-ee4j/jta-api/issues"
+        },
+        {
+          "type" : "mailing-list",
+          "url" : "https://dev.eclipse.org/mhonarc/lists/jta-dev/"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/eclipse-ee4j/jta-api"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/jakarta.transaction/jakarta.transaction-api@1.3.3?type=jar"
+    },
+    {
+      "publisher" : "Eclipse Foundation",
+      "group" : "jakarta.persistence",
+      "name" : "jakarta.persistence-api",
+      "version" : "2.2.3",
+      "description" : "Eclipse Enterprise for Java (EE4J) is an open source initiative to create standard APIs, implementations of those APIs, and technology compatibility kits for Java runtimes that enable development, deployment, and management of server-side and cloud-native applications.",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "e0a655f398f8e68e0afebb0f71fba4e5"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "8f6ea5daedc614f07a3654a455660145286f024e"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "0c2d73ab36ad24eeed6e0bea928e9d0ef771de8df689e23b7754d366dda27c53"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "1e07257b631ae3331a71d7cd9136152cddebbe786ba50c689bec618a9eb659be8e952fe0405db36332cb6c12c6c87c6d648e817c027ea8c6e0c660ce82f6f424"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "d68e1f600244d7a3628244e0265208ce08881f4ea33a3cd1f085886f7ce755cdd44bc6788ebda1baf8bc23b1f3c844dd"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "fb77e58872d4e3ef6475094ea96f1ce32a1a7c3617393fcab47c47cb84f6995315c5f805d518c69a0cea751ce980bf13"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "3619596135b169649ed16b75972c39614192d2a802291a7eb4c1814ef7dc9ff8"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "045c7f1ec7f9191cd2ff35fadf5c037aa596a288189185fd10d5fed89cd3661b6353945083f4c3943c87e343b61a556699f43f00a0e928c165e52d57fe514fa5"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "EPL-2.0"
+          }
+        },
+        {
+          "license" : {
+            "id" : "BSD-3-Clause"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/jakarta.persistence/jakarta.persistence-api@2.2.3?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://github.com/eclipse-ee4j/jpa-api"
+        },
+        {
+          "type" : "distribution-intake",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/eclipse-ee4j/jpa-api/issues"
+        },
+        {
+          "type" : "mailing-list",
+          "url" : "https://dev.eclipse.org/mhonarc/lists/jpa-dev/"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/eclipse-ee4j/jpa-api.git"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/jakarta.persistence/jakarta.persistence-api@2.2.3?type=jar"
+    },
+    {
+      "publisher" : "Hibernate.org",
+      "group" : "org.hibernate",
+      "name" : "hibernate-core",
+      "version" : "5.6.10.Final",
+      "description" : "Hibernate's core ORM functionality",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "9c4f43fc5936b6d6555ff6ece7865220"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "408fd5802391d8e6f619db9d7c6c0e27d49118c2"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "ed3693a0ae288dafff6155b03b7d743fdb9c9f432de37d7b894f44d92e3a85c4"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "8a6c11bbc9ae9768a9f54fdbef278ac69dcfaa848cefa3ac1b2f56ca0c93323f2ed61be576b13312cec780172666af5038e4b89a322a77859df83929e7124f5d"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "25690c68444a2c5d9a2b74fa2a811c1c424962de7dc94cd00c0b147c4f0af58f247b0ea5ccac004fb31e80f10e95c3be"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "4d5075e0738030ac3c991210115c42adc5b9108a23520bd129ec1e1c2afbf74d1d06dfa26d70549bad4b93bf4aea359a"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "833621051c7bebba299d96ca022f65ea36f64d9da1f28086288685d9a18b7590"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "77bfd3bf5fb4a7bdddd9e63bb90d70910dabb04585e50a124c1495b24d2bfe5d40758fb6c298ed5fcca19f8a94b3082419afc6f734764aa552e3e8c947a950f1"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "LGPL-2.1-only",
+            "url" : "https://opensource.org/licenses/LGPL-2.1"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.hibernate/hibernate-core@5.6.10.Final?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://hibernate.org/orm"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://hibernate.atlassian.net/browse/HHH"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/hibernate/hibernate-orm"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.hibernate/hibernate-core@5.6.10.Final?type=jar"
+    },
+    {
+      "publisher" : "JBoss by Red Hat",
+      "group" : "org.jboss.logging",
+      "name" : "jboss-logging",
+      "version" : "3.4.3.Final",
+      "description" : "The JBoss Logging Framework",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "b298d4b79e591843c1eb1458ea79f070"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "c4bd7e12a745c0e7f6cf98c45cdcdf482fd827ea"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "0b324cca4d550060e51e70cc0045a6cce62f264278ec1f5082aafeb670fcac49"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "60759c4340a7c1af0f10a5c2252e028150413d2437547f42018a94a838dc4a2bb24256411490a7e5f109b76305e2752ecf37def85e631d7e7b7e8461e0b54dda"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "1c07afd380f25c076ca0e568be205ede18c875471547133711f04bb2ffc9936c7c97708605cca18c9a98fc94b072caea"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "f17eeff5983e9e0562c90b8b3051b2dbee885818adb104ba8700a399f90a1a3c85a766686dafa06122cd6f8979561ea9"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "c41833778a14d364e29767d543ac402e93222616bfcc020552f0f037cfc6b02a"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "0dace1456d22070719b6e7322cdfb64b34f36f5c8f271f62026c691b00fe32fba50ac17f61b467160ec2b7cabdeeac77029ded3d7f9b1e08a4a0f709222a5017"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.jboss.logging/jboss-logging@3.4.3.Final?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "http://www.jboss.org"
+        },
+        {
+          "type" : "distribution-intake",
+          "url" : "https://repository.jboss.org/nexus/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://issues.redhat.com/"
+        },
+        {
+          "type" : "mailing-list",
+          "url" : "http://lists.jboss.org/pipermail/jboss-user/"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/jboss-logging/jboss-logging"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.jboss.logging/jboss-logging@3.4.3.Final?type=jar"
+    },
+    {
+      "group" : "net.bytebuddy",
+      "name" : "byte-buddy",
+      "version" : "1.12.13",
+      "description" : "Byte Buddy is a Java library for creating Java classes at run time. This artifact is a build of Byte Buddy with all ASM dependencies repackaged into its own name space.",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "c9149a2f7f9190bbf415efd4cc5aeda0"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "035ffee9c24b1c68b08d9207e1a2d3da1add6166"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "6a688bff5b0da4f4f26a672be6623efef94837f1dd49ef2d1f5f6fe07c06699c"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "3203370c94caf8fea95d881054778d78130a9656ef0576b712b51a5e85d25231cdc805fd616987b77aedb99e7604c1236a335c9531cd2836b745625f02321bc8"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "443ecfdb84d0756094a883c4d900f9b5a62b47f2dcc2ba1edea9a8bc38119ee35e5be79f7fbffd2295ccd5b6adc33c3a"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "4672d5f9c98830c4bc78073e9bd70643f19ec099b78c662af37ea50ce6df718d0d62049313fb0d55135b99552eddba22"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "13fd54f8437d9ddb05d6ce90ef8db313a9bf84fa7409549aa1bc129cac988af4"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "4a3e9b5ca73c089f889a094d6a067a37b8e9907755a80b32aed563d1b8df2c91c07a3be451d13dffe51801d71b7a7403a03895897d8ede9b339d3d9586b25e60"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/net.bytebuddy/byte-buddy@1.12.13?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://bytebuddy.net/byte-buddy"
+        },
+        {
+          "type" : "distribution-intake",
+          "url" : "https://s01.oss.sonatype.org/service/local/staging/deploy/maven2"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/raphw/byte-buddy/issues"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/net.bytebuddy/byte-buddy@1.12.13?type=jar"
+    },
+    {
+      "group" : "antlr",
+      "name" : "antlr",
+      "version" : "2.7.7",
+      "description" : "A framework for constructing recognizers, compilers, and translators from grammatical descriptions containing Java, C#, C++, or Python actions.",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "f8f1352c52a4c6a500b597596501fc64"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "83cd2cd674a217ade95a4bb83a8a14f351f48bd0"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "88fbda4b912596b9f56e8e12e580cc954bacfb51776ecfddd3e18fc1cf56dc4c"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "311c3115f9f6651d1711c52d1739e25a70f25456cacb9a2cdde7627498c30b13d721133cc75b39462ad18812a82472ef1b3b9d64fab5abb0377c12bf82043a74"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "2e811e531ce30a2a905d093a00de596cf04406413b60422db8252b46125cadf07b71459cf6ac6da575ec030a9bf05e57"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "bdf019332ae8714ef6a3904bb42bb08c1fe4feacf5e6137274884b0377d4e5b5f7aa9fe8e1ef5ca9b3e15f12320fdb67"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "babce5c8beb1d5907a7ed6354589e991da7d8d5cbd86c479abfa1e1dfc4d2eb8"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "3a8ce565280a157dd6e08fb68c317a4c28616099c56bc4992c38cf74a10a54a89e18e7c45190ce8511360798a87adc92f432382f9d9bdde0d56664b50044b517"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "BSD-3-Clause"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/antlr/antlr@2.7.7?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "http://www.antlr.org/"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/antlr/antlr@2.7.7?type=jar"
+    },
+    {
+      "publisher" : "JBoss by Red Hat",
+      "group" : "org.jboss",
+      "name" : "jandex",
+      "version" : "2.4.2.Final",
+      "description" : "Parent POM for JBoss projects. Provides default project build configuration.",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "489f7a97d2ed7ae34ea56d01b3566d57"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "1e1c385990b258ff1a24c801e84aebbacf70eb39"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "3f2ce55c7d71e744581488dc5105806aa8084c08e6e916a019bab8f8698994f0"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "635642582701f6ae26df91e39d5bfd9345c4c219da73e71a27f4740a4c0c7970f52cef667bb9cc4dd08c26d9b0447ee003c9e56d5ede68870976356c2fcc4a5c"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "ed9e4cf2b47f0891d5fda2a4a63650f0309a5e05f4b51b208bb0c0759dd1cd713e8db68816666ade0fc2faa855bd98c1"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "66c79624a37e19a65063c3d3c0e4779c18e33c2f558078abe1f05c69b1a85a6aae561f0aee1163c41d5efb4a315a3567"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "b6214feecbcb01f82e7442d614d5ddfb02efb686c0b603def92fdc7545f46412"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "0073443439cbc3897ea98f332c61422e0ffd40309fd93c6683a35f70df8e4828ed9e34025e0368ea55935d66863bdec895560054f1869dafd87f2bfc21f47ebf"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.jboss/jandex@2.4.2.Final?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "http://www.jboss.org/jandex"
+        },
+        {
+          "type" : "distribution-intake",
+          "url" : "https://repository.jboss.org/nexus/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://issues.jboss.org/"
+        },
+        {
+          "type" : "mailing-list",
+          "url" : "http://lists.jboss.org/pipermail/jboss-user/"
+        },
+        {
+          "type" : "vcs",
+          "url" : "http://github.com/jboss/jboss-parent-pom/jandex"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.jboss/jandex@2.4.2.Final?type=jar"
+    },
+    {
+      "publisher" : "fasterxml.com",
+      "group" : "com.fasterxml",
+      "name" : "classmate",
+      "version" : "1.5.1",
+      "description" : "Library for introspecting types with full generic information including resolving of field and method types.",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "e91fcd30ba329fd1b0b6dc5321fd067c"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "3fe0bed568c62df5e89f4f174c101eab25345b6c"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "aab4de3006808c09d25dd4ff4a3611cfb63c95463cfd99e73d2e1680d229a33b"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "7fc4764eb65227f5ba614698a5cf2f9430133f42ec6e2ae53b4c724ee53f258541a0109fe0659e0b9e45729b46c95c00227e696b8d1addcd772c85f877658c9a"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "28b4780b2353ebc08dbc02c9a343527a9062a0455bfb4ab135cb639c03e5dfd9c2250a835c44d5f17d275667c2009694"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "b194ace8f1f49f410286bd859866678b95a1b2c6f73e41f48291eb7438dffea57aaa9b177459038b6997771ce4d1cee1"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "50234c94efed4c816eb77bd2f70b869c9f89ddf8ee73dc25e354f4d0b81b3e1f"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "9886421726066b313a62283a6811b76d904ea1c1e9b7b2d850cb47afa189b03cdef053c8f7f6b79e77f2269c45f8cc2ed75c3389e96594b50987fef311d5a25f"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/com.fasterxml/classmate@1.5.1?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://github.com/FasterXML/java-classmate"
+        },
+        {
+          "type" : "distribution-intake",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/FasterXML/classmate/issues"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/FasterXML/java-classmate"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/com.fasterxml/classmate@1.5.1?type=jar"
+    },
+    {
+      "publisher" : "Hibernate.org",
+      "group" : "org.hibernate.common",
+      "name" : "hibernate-commons-annotations",
+      "version" : "5.1.2.Final",
+      "description" : "Common reflection code used in support of annotation processing",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "2a2490b3eb8e7585a6a899d27d7ed43f"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "e59ffdbc6ad09eeb33507b39ffcf287679a498c8"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "1c7ce712b2679fea0a5441eb02a04144297125b768944819be0765befb996275"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "9ce69f19b2e080071a69a2faa992be70b2c153d94862c306f784d1f91fe66e01139c13a3b4f156ee17bdc58ea9c93b61e2dbdfc43152d43896610251488c6e24"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "4f1652cc7f93556ca615f7a70a63e22004f7e1325b6d38492c5601d9b13f9ee3292b7e8919c1a0ef41de0266ed84b941"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "c39a9a94055696454d0ecc5c9718ca1ca7ea05f3b22eb8991c69f31e976a595b86fcaa37fd030c03c0860610bd7251c4"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "a2dc556200c3503ae769c6efa3634a94ac30f475f60b9fd7e478c8919e326720"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "4c791c5d5c43a3d4907f495966d89bd281d90727e3884d889b07a6e88c0ad3f9a712fabf4f2d73c57412d9eff1946ac48ad5450067ca9f6e83212ab09c18907e"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "LGPL-2.1-only",
+            "url" : "https://opensource.org/licenses/LGPL-2.1"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.hibernate.common/hibernate-commons-annotations@5.1.2.Final?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "http://hibernate.org"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://hibernate.atlassian.net/browse/HCANN"
+        },
+        {
+          "type" : "vcs",
+          "url" : "http://github.com/hibernate/hibernate-commons-annotations"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.hibernate.common/hibernate-commons-annotations@5.1.2.Final?type=jar"
+    },
+    {
+      "publisher" : "Pivotal Software, Inc.",
+      "group" : "org.springframework.data",
+      "name" : "spring-data-jpa",
+      "version" : "2.7.2",
+      "description" : "Spring Data module for JPA repositories.",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "5e92ee78425c9f895993ff68687f6113"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "1b8783e98d4199c8fbcb46765fbfce02f41907fe"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "75a6a455d328728f4985cde9220267633b4e0cf2509f9d7c4aa9aa55c6ca2c89"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "e78a36a1a4574aef52b30da4abe7067a603739544daf8f0ff645d5f79f6442a46162e6cf8ded3794f411ad72a7de9463a1cfea2345178f4676f2715cd2ba28a8"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "770a77e03e3653ab36fd845ba4051f0563f789bb43c54eca201650f2954f5de3ce4aa936ae4b87dd2b3d096906003eb1"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "12a8e2b22615d063f96cd91eebdf25d3d11a668b691a6b522ba651cffe4d9107cc6179f7ca2313198643fd3eacedac77"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "064a4d7dbe7c44f3748e9781a150e2600e8bcbc3ce7a20a942c256359cf6464f"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "b3e3db43c8413bf3c56f359af62a295de9622de9d36dd332fa360fbdc236d19b1fbb80d548fa07624a82f583583b089a57dea16c62c062b1f0c56206c9f00a26"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.springframework.data/spring-data-jpa@2.7.2?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://spring.io/projects/spring-data-jpa"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/spring-projects/spring-data-jpa/issues"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/spring-projects/spring-data-jpa"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.springframework.data/spring-data-jpa@2.7.2?type=jar"
+    },
+    {
+      "publisher" : "Pivotal Software, Inc.",
+      "group" : "org.springframework.data",
+      "name" : "spring-data-commons",
+      "version" : "2.7.2",
+      "description" : "Global parent pom.xml to be used by Spring Data modules",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "e488e8db2bc5e559c79f09572a0797cf"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "9547d1234cb380234066aef60129bb2ddfdc6347"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "dfa59582fc3315bf3e3e4efd73fc4399043e4e18ff07917e31f5269a82bc7bd6"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "74ae2a5d8eedc5004ebb25d041a87a3fd7a754886450ce6cfc1d4f303a10d186ae3dac43f6b697fa846115c7680be797b9f93436164abff7520e0c6f61d7c208"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "a6ed78fea3590fdc89dd9efc36509646899caa87af2a185f80420f251d754b48bfc40ea91684729d210c984394019057"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "5734c976363d397be226aeb61d1a3d9d8de8e8279eb610831caf0badb5c3f011f4b5da610d311e15f3d2bfabb0ae8178"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "7deaecf60788c318a8c90654ff4d46416b2adcdb5647fd0eb96be40ac36e0504"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "d59e2ac3d21b6dfb3646908bc85b97724b027f1ac1426ac5f03704ac423e1d7e3d65a0ac2f50dc6174e67bd6d7b7c7495dd43c0dd7f54ce86b6043581b74d427"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.springframework.data/spring-data-commons@2.7.2?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://www.spring.io/spring-data/spring-data-commons"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/spring-projects/spring-data-build/issues"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/spring-projects/spring-data-build/spring-data-parent/spring-data-commons"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.springframework.data/spring-data-commons@2.7.2?type=jar"
+    },
+    {
+      "publisher" : "Spring IO",
+      "group" : "org.springframework",
+      "name" : "spring-orm",
+      "version" : "5.3.22",
+      "description" : "Spring Object/Relational Mapping",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "f4cef9fe1dcfc5e6b534851f8f2d979b"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "abcefbf4895a3daf263cf385cc66e924db92d254"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "8ac282390de9cf94996326297d9aefdfd02930a8d115fd62790ade28f05515b1"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "24d731590ca3867e58bd65a224f6138c465ff397978bd1b2bf212a0dafe6167641882f05b0fd236b733912b8d0f977a73989eed86bd4218ecd9a5b5ecb099235"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "52776a942281ccca53c5e24e37c3b2e2a85eedf5723ca9a0bb602de5d77d6e7defaa6fe77b32aef4e743738bdd54b0b8"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "f8906009fb9242fa53209bf3d5a59ea3d84570318817e0de740ec59ca600274ded376cb440fa379cc813ad5b95469a89"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "cf598b0e81728122d9087611f504b4d119c0db086a5c6e09eadef7d46a575c73"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "82c6c4dd4fd5e1901b53a7bfe929e13fadb2088b837f2b925b281d61cac0687b844e89e2b3b500fe67c4d962f4fef4b3422122ebd0125a5ec87ca12d61428777"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.springframework/spring-orm@5.3.22?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://github.com/spring-projects/spring-framework"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/spring-projects/spring-framework/issues"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/spring-projects/spring-framework"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.springframework/spring-orm@5.3.22?type=jar"
+    },
+    {
+      "publisher" : "Spring IO",
+      "group" : "org.springframework",
+      "name" : "spring-tx",
+      "version" : "5.3.22",
+      "description" : "Spring Transaction",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "84646a02ee3a0ed0b20d7ce9e6ecbd94"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "d0b3812ab20987a13f3a9ae7b4c54f619e034692"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "7d93ff5f35374e5a0c5361e42c6209d660ea81da31fe580bedfe8a2067ffce8b"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "ec2e135a80924a60c8c0970a60097eaec76ba8cee3e1afcd77bc6416a08be5d990364b367bfedde9bdfddb496f6775e1768891a6adc408ad109a27825a5689c9"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "f5a01534511b9852e835622fc9ee303e19e983cc4c5dbdefb58a6e920b0bf17e6ca98c16a3abf9fc0dafc1eec455d615"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "6352440b579d3bcacfc4377b089eac5559c3c5f08f79a7afe066aed2fc758f1a3be18ff82a823746ec2e47594124d6c1"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "f29047b7bce614add3bcfd87b8fc5c1c08ed02afdf4091151773917ba59837c0"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "1fc82feb5b54311ff33cf7b134691fecf7e796a9abd12984a4ab2638a70b37c398c4ce3ce7bcd1b36021ecd0ac625c994ba011d578935436e0a7ebc593c54219"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.springframework/spring-tx@5.3.22?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://github.com/spring-projects/spring-framework"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/spring-projects/spring-framework/issues"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/spring-projects/spring-framework"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.springframework/spring-tx@5.3.22?type=jar"
+    },
+    {
+      "publisher" : "Spring IO",
+      "group" : "org.springframework",
+      "name" : "spring-aspects",
+      "version" : "5.3.22",
+      "description" : "Spring Aspects",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "7d27212a6c8652bb56705e9c59cfe1b0"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "1fdd8ac7f557ba12bb59086edfe3a9cdf6d918bf"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "576489cc76ea4d058bf07227f6a6eedfc87e6045614ffa9e9f0b0d8ba3f48003"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "abe4f62ca988d3ee8fa0eea582552ad32fff03e5a0d55aee1c425bd1b24ecf1dde4c313521da33dff3e12b5466600e054ebdeed4f94b8c3e1667290745d186c7"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "7ab627ce19a96dfcfa0153659840e968d1343547b8cb81b849921f20e0c4d6f2ddbbf8b6c22e30089caba38e5e2f5b94"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "7f4e5c6e0ca60bd2186fb9d534351b6384cfe482ffb243ff0da24583c8b5b545c2b9f625819bb89c6412a29ca68486b1"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "50292ba3cf29ab128bf6cdea912aba2210b6b1ebaf7e2c28b0a6dbd2f81e6c08"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "e0e127a8d773992262ec1a7e41e79577c7d4f17a5c8099ae0aca194aa7f7572add4c0164a2e12a4f0ad3496bff5d23582029bf7c00ea7645a15c2bf5456120a0"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.springframework/spring-aspects@5.3.22?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://github.com/spring-projects/spring-framework"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/spring-projects/spring-framework/issues"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/spring-projects/spring-framework"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.springframework/spring-aspects@5.3.22?type=jar"
+    },
+    {
+      "publisher" : "Pivotal Software, Inc.",
+      "group" : "org.springframework.boot",
+      "name" : "spring-boot-starter-web",
+      "version" : "2.7.3",
+      "description" : "Starter for building web, including RESTful, applications using Spring MVC. Uses Tomcat as the default embedded container",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "b0202373d8b5c38481b401c4a48fb00a"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "9e36c7517c4f872b69d0665e1dd46bd6d83c43b7"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "356105ca8dea2264207f7ca30c2ad252ae0a989e61a2c8cc8f64b2cbe4e61fbe"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "e1df0ad21b1aca033d3e666ce3d544e30f8affaa80e294cc29048146947be73a68b7b8be89202525c6d4ebc0106318a6424780e2781e65dc95adc23eacb10509"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "c702cac278accc3977ef8599140e8c8b3c8f542d5172f2eb3b94bf35487876dc3bc6621e64f35ec8ddde8361936602ac"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "32174b20ae8cad4c1613fea81a752f58ee23b1277bc1c2a66747dfc19a403f453554caec045a5d73424cf3157ff661a8"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "c41986b49469994c7c54f2112398c81bd72d17926999b1e56a28d544334e6490"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "a9e3f8dbb44152bda4ba3ce2f618d05374ec350dd15e878abbb9f25007821b503dadb69eaa07d2dfdcebd10b9e5f7af3b7a0828c6a35dae8bf92105732690a7e"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.springframework.boot/spring-boot-starter-web@2.7.3?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://spring.io/projects/spring-boot"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/spring-projects/spring-boot/issues"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/spring-projects/spring-boot"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.springframework.boot/spring-boot-starter-web@2.7.3?type=jar"
+    },
+    {
+      "publisher" : "Pivotal Software, Inc.",
+      "group" : "org.springframework.boot",
+      "name" : "spring-boot-starter-json",
+      "version" : "2.7.3",
+      "description" : "Starter for reading and writing json",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "b115a29addf8568e87ca7dea7ca8de51"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "38c88404d68926aaf6c0914199e8c5e766946de2"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "b41db71097823e28aafd7fa45eb38c546bd32ac86614cffaf54b1b93bf955952"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "7fb627d880ffd920671f0d7b9bfc6b0edee0e505c43dbd0dd114e05d209b853bcd5e6b2578b9d48d84d9f3d9b026d1d3fccf5ebc070dc8f388e092f988068985"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "346e4a54289a3b8513581072b6ec6282b02736b689f975e8aa175b037124a7aceacad93bbc40f153114c9627870492df"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "0c6b38be19ff152f273d375ac8d3ce07609c15ee15352440cc3065588671206a028a1ac67b7d38ce0f3010532c02aa0f"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "1480b8f0cce248186dc9aa6e6b293b85d287f468c0a17ea7451619814e7993ad"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "92b12ef5057914371e5857ee62851f54af0a15084a47c448606a7bb58c12975f55338eb5c689f79cc666b8c77b16ab5f883a6f1a399338f2364901508bb870a5"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.springframework.boot/spring-boot-starter-json@2.7.3?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://spring.io/projects/spring-boot"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/spring-projects/spring-boot/issues"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/spring-projects/spring-boot"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.springframework.boot/spring-boot-starter-json@2.7.3?type=jar"
+    },
+    {
+      "publisher" : "FasterXML",
+      "group" : "com.fasterxml.jackson.datatype",
+      "name" : "jackson-datatype-jdk8",
+      "version" : "2.13.3",
+      "description" : "Add-on module for Jackson (http://jackson.codehaus.org) to support JDK 8 data types.",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "8dfa569e8efca9df24887bad202520fa"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "d4884595d5aab5babdb00ddbd693b8fd36b5ec3c"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "1ece4fa7591be315b38aa986ded0ebc8dafcabdc0260f7819e663543a401bfdb"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "0d2a20ea9f30330e65feff7d9873faddeaec443d51b5b5689dcbd6abba6f0ce5b86ce7777b95899e33cc88529351043e414fe53aaf8a65081ef9adbb6b2ec2be"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "3a42b22faf4c401ce4f7b29514a1655907a81b89b3fb60f0e4ab78c80c335baa5586b7e9bf25c3bf33af4eb002531875"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "1a9f005078c0eeaef0204e7dd98f77b1adb95006c8b21438453d203cc7765a89ca08a6633ffee652532d4d17b9f0d1cf"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "f4298649801a97fcb84538ed20096683945176a39675b5d78ec78354d198e42d"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "3b2d112645d3d1c2b74f3519754a9e672c18b3e729870891267c4c76c92d01814bbf04a89a29744fa5e712f9502375f12515660f833cf20b3e3e7f8e3ffc5ae6"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/com.fasterxml.jackson.datatype/jackson-datatype-jdk8@2.13.3?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://github.com/FasterXML/jackson-modules-java8/jackson-datatype-jdk8"
+        },
+        {
+          "type" : "distribution-intake",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/FasterXML/jackson-modules-java8/issues"
+        },
+        {
+          "type" : "vcs",
+          "url" : "http://github.com/FasterXML/jackson-modules-java8/jackson-datatype-jdk8"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/com.fasterxml.jackson.datatype/jackson-datatype-jdk8@2.13.3?type=jar"
+    },
+    {
+      "publisher" : "FasterXML",
+      "group" : "com.fasterxml.jackson.module",
+      "name" : "jackson-module-parameter-names",
+      "version" : "2.13.3",
+      "description" : "Add-on module for Jackson (http://jackson.codehaus.org) to support introspection of method/constructor parameter names, without having to add explicit property name annotation.",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "b6e20ffb82b7f26f19146f5cd5493738"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "f71c4ecc1a403787c963f68bc619b78ce1d2687b"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "6c4c82d16460f41982311efbdd6285a5c898beceacd8c913ef9e3a1ed1a1f4e0"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "547bd36751c50a261ec2f7210caefab38cbfd042af3aedbe016de15863bb19bfa5590d0d213c7df362330e1ecf810b5e5840ddce04c3f53a0f081a01d5dad8c1"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "5f873a0fc1bba649494e58e9d06f1889d17f9d3a1434ba74d436656d2194c255b2f599cf2eb2d8159a59adb2440b8677"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "c404fb31d92431be6e94a2361811df40cbccb3df5a347d86b165a938c9be926c54edd4fe02c45867fda1e14088c668ee"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "7e547be835120f96e6c413010c11142d026e0c7bb80a3ee203f2bd8738611d83"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "2248c1b110f9d87f7077f2435e87989bd67b620c872cebd2046f014274c023131132bbde0cd635ab53bfc295c0f35905aacfe8f1eaca3e22f947db489bd6f18f"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/com.fasterxml.jackson.module/jackson-module-parameter-names@2.13.3?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://github.com/FasterXML/jackson-modules-java8/jackson-module-parameter-names"
+        },
+        {
+          "type" : "distribution-intake",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/FasterXML/jackson-modules-java8/issues"
+        },
+        {
+          "type" : "vcs",
+          "url" : "http://github.com/FasterXML/jackson-modules-java8/jackson-module-parameter-names"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/com.fasterxml.jackson.module/jackson-module-parameter-names@2.13.3?type=jar"
+    },
+    {
+      "publisher" : "Pivotal Software, Inc.",
+      "group" : "org.springframework.boot",
+      "name" : "spring-boot-starter-tomcat",
+      "version" : "2.7.3",
+      "description" : "Starter for using Tomcat as the embedded servlet container. Default servlet container starter used by spring-boot-starter-web",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "903033ef3f3622647594bf95e4715722"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "7a5998baaa05d5e7a9af7194a21f2ac3512ba7a0"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "d9696b94a38f237a58dee2b2d9620e2fb12ce4e73e4d23fbcfce12607885c528"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "416f7bd6b66e880b13f745d883995eec6f7a5be8110746f12ba1b3f3ddc5c2a51eae8fe3bee930be84a77b9b9563195a8f5f66de6c4158803bc9c80509d38621"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "5b687ab81363e64acbb36be93c3b4ed285221be769c5d3f9d98ccbea2fe8d571e104dfaa77712866b7a3d8b66f7774be"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "6250e2b44d735f02d749320bd80bbfd22cf2bf01b9d3f9d6f7f3367123834f40206d05fc963c22a0bd53fb1efb281ae2"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "61171bd9a499158446229338cb40dd527f5bf3e77c0cde5df867a7c6275e1bbb"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "1f0194a600eb4d8b3e833dbe278c26907da540cf83a161253477d3bc322ba89a65b29f38074db352f08721d6213b35d63af1af8b75661ee0e2710fa3c7d73462"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.springframework.boot/spring-boot-starter-tomcat@2.7.3?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://spring.io/projects/spring-boot"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/spring-projects/spring-boot/issues"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/spring-projects/spring-boot"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.springframework.boot/spring-boot-starter-tomcat@2.7.3?type=jar"
+    },
+    {
+      "group" : "org.apache.tomcat.embed",
+      "name" : "tomcat-embed-core",
+      "version" : "9.0.65",
+      "description" : "Core Tomcat implementation",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "67ccecf5fc96bd4c2b20440da1597ee1"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "a24c5f379b2ec343a167a83332b75c37f26b2ae7"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "b4755695783b3ad01e8ba15a4391e626bdfdff567a01de2079f12bb3421b347d"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "be9910109ec88e4154f1c9d28059a3d2e8ae10ff308f34cea56c660c4c45a6bb8a1b3cc299db9f09ac6874282969091fdabaab9da67ce0d1702c621ea01968b2"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "cc234ac5fd05c2173b8b4ee7bb8ebe17d277f4ebb4da56fb7d9806e4d17bc722b4b580d062e395837a72ef8651ba8a6b"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "425e4a2aa7837488e221555a8934cf26f2e3e7a4cb916cb765e4d9868ac15663fe4d65867f05a170a5c0498c9cc43ef6"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "40b765d776b5918e001da3b94c5affa12e0d41f4d591e781b10f85bd679430d2"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "8271df9e531c678ae9da87dbf1bc16a9c6fc07ebc5595fee35a9826c4ad17f0323077317369db7f58756c5b5450e14dfa631afa54b323ab5eb60f5d0557d3b20"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.apache.tomcat.embed/tomcat-embed-core@9.0.65?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://tomcat.apache.org/"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.apache.tomcat.embed/tomcat-embed-core@9.0.65?type=jar"
+    },
+    {
+      "group" : "org.apache.tomcat.embed",
+      "name" : "tomcat-embed-websocket",
+      "version" : "9.0.65",
+      "description" : "Core Tomcat implementation",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "0e951a3fecce7dfdb63ea0793f2f5b32"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "bd70dfeb39cc83c6934be24fa377b21e541dbe76"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "a5c71902c4d26153f1256491362dc94e6598e70e3ba06f19ee02b1dfcd392470"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "f6c5d3f28b1d6d9b9ac7937e61ecbdb12ee779614fa049b8659786331677c5767d8ced9d93b1659a88ac00790c6297e029fd73e3aa96fb5e6c95cbde23de5e26"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "f2514fb2b7c335ee1134bbc506670be729428d0bd241507fa0d665613f52a65186abe9b7e9c91b517627d34ab7abc365"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "24427747f5453252838938bc4a9c7ad6547079f62d5d6f42bb69fc8b72f42caae68489785e169276072561d6e48a8bdf"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "459da6d372e1d9f8ca4e9cf33bc6ca1f6cdc95c6d1171fb0838e0b8a4e2df2ab"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "55b18bfe221ba157635eb43bb25f129faa32ba98886d384a9e208aff15a8e124013050cd7ad6d4d1dbc3a79ed6716404d7e483ad7bdeb8dab898eef612ff4b46"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.apache.tomcat.embed/tomcat-embed-websocket@9.0.65?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://tomcat.apache.org/"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.apache.tomcat.embed/tomcat-embed-websocket@9.0.65?type=jar"
+    },
+    {
+      "publisher" : "Spring IO",
+      "group" : "org.springframework",
+      "name" : "spring-web",
+      "version" : "5.3.22",
+      "description" : "Spring Web",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "6096e895ba3cd63edbf3aa2ee21b84a9"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "fdab9b8d8df2e6a8fb90f2481c361bcf2c129567"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "d201925a5f619a5f51107ed07043a847c645773165c954bc34fa5983fa043f1f"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "c56a00c97d3b5c432cea48d3e794eb0d3999d6c6439d70b13365db623c41c7ab9ce065bb58388bd38572a6ba54bbf357793e520de0a07dcb42967e4e167e5b4c"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "d47ed3e83dea9006de8940cae1b440597a7cd869532e057f19e75e4bdca5653f10b9de0213665bdeb6286cac64a7c852"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "ed323b4a5de35d92ed413d86a4eded4f133dbff4da548e2e34e98f6abd56c53141887c50ed024c0f45b5e48d7937621a"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "1b45711721eec8e6a3ba4b208652837db29ffa95eca667b94c9e07a48694607c"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "f25311622862d97104aa8839d369bdf9066890e514412ea03865674559a4e1081a652606c786d44a4cd4645d5fba4022d3f10afdddc4607164cfd579165c303a"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.springframework/spring-web@5.3.22?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://github.com/spring-projects/spring-framework"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/spring-projects/spring-framework/issues"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/spring-projects/spring-framework"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.springframework/spring-web@5.3.22?type=jar"
+    },
+    {
+      "publisher" : "Spring IO",
+      "group" : "org.springframework",
+      "name" : "spring-webmvc",
+      "version" : "5.3.22",
+      "description" : "Spring Web MVC",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "511ed52d5c8ffeedd6529bebcf9d86e8"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "519d86b7ac9b8b6bb54739eb4eb73dc13a263b28"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "243192abc127cd3544a7077c61575dd61b2fcd86a77a63c63cf119fc562fd961"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "3a3c4b0a5a01bad22bca5dc5239c01b0c39e9469600ffee268b28cdebe8d330f2c9d9f493914dffb66ef1802d88e71c3b4a1073315e899c3e37f267c1f265eb0"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "c8baa3430c45ccd16463b88f3062fb55a5fa9afdf26b1b4bdabb719ff928ed8150fac86e7cd06e98c37a353c2d4fcdf2"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "58d19fef8d4597347b4fabd55bdb26cc8194bc4257f455546039d4f6bda0ae37b6acace7fb2b9f4ba2b38d279ed6e2e3"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "caa43082d30e2d69dd549f72851ed7509ef8e1453ab48ba4702c095b137714d5"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "b50f1a99318c786aa63bd0be6c51cefdac57cb3b42768f96d811c7b426915c6bb6d51f0c590b4742d2b915abd972210f05dc5be10536b89f094e543f3b898caa"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.springframework/spring-webmvc@5.3.22?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://github.com/spring-projects/spring-framework"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/spring-projects/spring-framework/issues"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/spring-projects/spring-framework"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.springframework/spring-webmvc@5.3.22?type=jar"
+    },
+    {
+      "publisher" : "Spring IO",
+      "group" : "org.springframework",
+      "name" : "spring-expression",
+      "version" : "5.3.22",
+      "description" : "Spring Expression Language (SpEL)",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "1648040f13200e725ec6393c6ffa1f9c"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "c056f9e9994b18c95deead695f9471952d1f21d1"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "c4088592b55c8c29888a3fefdd1e0ba8192b4216c3be963ed66a5c6b82b53428"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "7e1502884e9343ac70b6cdb678454444f5ecf33d80715f90da1e5cd196f5bac5d5603c671bb9479986e36185782fb5e7b1bcb983a3e8939f1e57122e8891134f"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "ecf120bc08b15c99c836a3bffd75c29f1ea913fc8334d7344814c308a61d04eb304be6c5321cb7ba684c6b3adc804cb0"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "653e49cfba9dc9497c542cdc4dc2d10cae10f4b3f89dfa2e08c64eff1e15e66ecc7ec208ecc4c41bf77b95d3d784487c"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "ac0b0e4ef5525c4c61556f8dae2956210fcec8e3bd104bcef30716ce5efcde8f"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "023830cabbacdf063ce2c2e4f67ef7f932ba5e147fb50d81720482729731530082e4c699a4fb001c9d8c53c69e74a61102460865dbbbe6211b2665f05c97afd5"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.springframework/spring-expression@5.3.22?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://github.com/spring-projects/spring-framework"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/spring-projects/spring-framework/issues"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/spring-projects/spring-framework"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.springframework/spring-expression@5.3.22?type=jar"
+    },
+    {
+      "publisher" : "Pivotal Software, Inc.",
+      "group" : "org.springframework.boot",
+      "name" : "spring-boot-starter-validation",
+      "version" : "2.7.3",
+      "description" : "Starter for using Java Bean Validation with Hibernate Validator",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "f3212373cf22f24f4bbe8fb0ed919ea6"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "c2e59c8d4df01dfecbdeac96693944ffcb2527ae"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "1d6ba58e036c78911c598e84f67260013fb2affbea2fb426dc51a49626006699"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "383bd99a66feee62a84095e0e093cc233dd2041f0b2cfd8c78f21baf7d719409f8000dfe021b9ff515579d695633b598da5ab48d4bb2e949cba7391e6c2825c8"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "70446098f0ee24cd9d34f9eda0732639b18dee225af8018bc8b160e47f01770a2bfa6077856248030bdf858c62a3cd48"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "f4bf7ccdbaa22e694d174eefc2b12f4a0898d4bcc077e68f7afc4299f5a8993f8cc4737e78bf4cd64a2e9bcd0b184f64"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "bf1eec55bb6ab5e127db888db8920314d1dd59aca9edab1d9f01b727205b9334"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "627babbd8c682d44f7ffd677a0981d052e534ba1fb1ed77bfaa5a38d150e24ceb6b1633c1506c86962fd43ab6b8bdc3109b2d4b1780920f56a7ff4e4f8e00c6e"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.springframework.boot/spring-boot-starter-validation@2.7.3?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://spring.io/projects/spring-boot"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/spring-projects/spring-boot/issues"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/spring-projects/spring-boot"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.springframework.boot/spring-boot-starter-validation@2.7.3?type=jar"
+    },
+    {
+      "group" : "org.apache.tomcat.embed",
+      "name" : "tomcat-embed-el",
+      "version" : "9.0.65",
+      "description" : "Core Tomcat implementation",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "6510b8b32f9226e27d75aaddd802eee5"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "d278157387e59a5f9b48091dcada22b7c74aed00"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "b90a1a2a257103e54f39195ced80fa70d7ffe45813e1e226e0242c29c7c82879"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "bff34ae27291027cde7ff95e769e806f6748655a9e617cba64453d0e9b04e6b49c0abb87fcfb68116bead7c4598ac717a43fa024b0d62721a8c48caa88e37031"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "d66d61d3d0b64f0d5e2e187771cef478becd0b4a85fdbed6a2780b95031b7291aea8060cf6076447049a51d93b9de685"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "574d80c56e436dbe078fe3ac614709ddef827e91809e775045232bea4e26155968cf13a73b018a3929646d969494c531"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "32e2cdbe6ebb6499efac3747dbf4dfdc010f12f8477e0ebd44b0f1c141e21fc9"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "585a4aadf5ac27fb438801c9ca83cdc1860ed102eabddfdaea0913c8f25a4c50d1d86fa1e95242c2010d468deb1ee899b6a2b718ec4cf44a5e90b8de640a8937"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.apache.tomcat.embed/tomcat-embed-el@9.0.65?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://tomcat.apache.org/"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.apache.tomcat.embed/tomcat-embed-el@9.0.65?type=jar"
+    },
+    {
+      "group" : "org.hibernate.validator",
+      "name" : "hibernate-validator",
+      "version" : "6.2.4.Final",
+      "description" : "Hibernate's Jakarta Bean Validation reference implementation.",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "363092a69966c14c7d32f6c8db6369e8"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "5acf6de251d9e29102a1f30657cc3151ce3c8aeb"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "6015910ff12ea61291f277bb6ed80d26b3eae0d45d4e6bc482ad492a2a9ce8bb"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "08d4b7f608ca57d47a3eac87dc703b7315dee770e70095805bc78f04a0e773b0a4a262a170f3d2fd6083a139828bd4ceb2766cc621cf062bec57f2a4cc4ac37b"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "15c902d115ec4856813443fd1451b259357cd104933cfb976b8c8d391bdf21b46b56acb3de259b91073cd63e214dff1e"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "a72561de0ecc80d95b10e8af66a0c5a8562f97cdc7ac3d898c1b20b9da68bb0839552b19ee8ade86fe4f9bc3aea3e9c1"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "2313d7d1742af95bf00b8d4e521dcfcfea1e7510220c9acd46c091c208959a19"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "3fce0cd1a22d383fe498308f1e30e34ae1239b11fddcf1fa7a9dff8f27eb33a5cac4993b3c3ccebaa656302a2cc20722250aa88eadf35f4fae309dc59c4b92ca"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0",
+            "url" : "https://www.apache.org/licenses/LICENSE-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.hibernate.validator/hibernate-validator@6.2.4.Final?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "http://hibernate.org/validator/hibernate-validator"
+        },
+        {
+          "type" : "build-system",
+          "url" : "http://ci.hibernate.org/view/Validator/"
+        },
+        {
+          "type" : "distribution-intake",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://hibernate.atlassian.net/projects/HV/summary"
+        },
+        {
+          "type" : "vcs",
+          "url" : "http://github.com/hibernate/hibernate-validator/hibernate-validator"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.hibernate.validator/hibernate-validator@6.2.4.Final?type=jar"
+    },
+    {
+      "publisher" : "Eclipse Foundation",
+      "group" : "jakarta.validation",
+      "name" : "jakarta.validation-api",
+      "version" : "2.0.2",
+      "description" : "Jakarta Bean Validation API",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "77501d529c1928c9bac2500cc9f93fb0"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "5eacc6522521f7eacb081f95cee1e231648461e7"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "b42d42428f3d922c892a909fa043287d577c0c5b165ad9b7d568cebf87fc9ea4"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "3ca8556b80ca809b3a43fac31469702bbad62a00e63b11a304dad1e372d9f6c128357463a4c70c423055941c7e2e417f87a9474a204d189c8e4b62f42047c8eb"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "6ae3963fd6a5e83b068a8344b88f6bfbd26d29cee64193025bc5e98195678e49826463da27a7a1c15cd83b2149d57a94"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "55a570386718064b422f9ebc0c0c07f0b37259e44a14c9a16c20e945402339b1d01b7d6969ef40d6b5baf5bce3e1161d"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "1ff48fdabab86a398b25e491e6ba4fd9b62d597314202628a3cfedf723c17f21"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "c23bb0b43fb0c39d4c9d2cce0cd38334fa7c253130f0bda3007d9f7d2dd451c0896ff4265ee2cc35024fad282f9ccaa398c19874775d9cabbb786843fae155d7"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0",
+            "url" : "https://www.apache.org/licenses/LICENSE-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/jakarta.validation/jakarta.validation-api@2.0.2?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://beanvalidation.org"
+        },
+        {
+          "type" : "distribution-intake",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://hibernate.atlassian.net/projects/BVAL/"
+        },
+        {
+          "type" : "mailing-list",
+          "url" : "https://dev.eclipse.org/mhonarc/lists/jakarta.ee-community/"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/eclipse-ee4j/beanvalidation-api"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/jakarta.validation/jakarta.validation-api@2.0.2?type=jar"
+    },
+    {
+      "publisher" : "Pivotal Software, Inc.",
+      "group" : "org.springframework.boot",
+      "name" : "spring-boot-starter-thymeleaf",
+      "version" : "2.7.3",
+      "description" : "Starter for building MVC web applications using Thymeleaf views",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "59e3d0a58b776ccf776ea14303553bfa"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "3dc30e21fe12e5ebc6beef56d1cb5d59fbc0b285"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "164cdab88cb340fd37dafefeb449ffa2df495c53fd41385cde5ba9695b51c7cf"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "f314714f733ca47935ccbbd68c141d8780ad0d452d335815738907e434813350730a459d688ee1d86d6f21b645bdad17b3135421d9bb8f47e4641f86f80f470f"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "da3511ceef4e2ea23e63506d2fdd2705b55e4ecd8ec1c72e72dfb9f00e2ef4cd480f4065c5e41078fc2917ced619975d"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "b5a21736bde6b2625972f27a50db405de292c1ef589534a53e48300a491f4849b4e4da5262e236a2905a7dceaf63ad52"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "87e1f9509fbb71a115d19958728c389bef9d152ea83c4a0c7ea7b459a290f753"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "99904943f6eac9507fcf9b983806df1648a9c39a6993ef93dc519db1dac27c690c05304a2aa3fa99bb25be79f06980dd2caa9843fa71d1c84e74adf2ec0aeb3c"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.springframework.boot/spring-boot-starter-thymeleaf@2.7.3?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://spring.io/projects/spring-boot"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/spring-projects/spring-boot/issues"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/spring-projects/spring-boot"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.springframework.boot/spring-boot-starter-thymeleaf@2.7.3?type=jar"
+    },
+    {
+      "publisher" : "The THYMELEAF team",
+      "group" : "org.thymeleaf",
+      "name" : "thymeleaf-spring5",
+      "version" : "3.0.15.RELEASE",
+      "description" : "Modern server-side Java template engine for both web and standalone environments",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "ebfbdb4cd7ce2dd399765b874ed4fe9c"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "7170e1bcd1588d38c139f7048ebcc262676441c3"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "d254da927435a517cfa1a5aed5b27b74818418981ef3b816e8da89e4390b52d5"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "4e85b7285e754c11b582ae419544c92a6209be306cc69d3863d1e3f14a50a2916d53744668f86d4a1eb8a646985c0e98bc8cb3ccf722e865ac0a44b25142ae8d"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "b75286eddfda06304ca2210a04cf6008549f80aa0a135deb47c3b0abdae6e02e67c82067995e85052a1d1f00413e4f7f"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "5bf280ac656a964f7d49ae1b99b32090f6ec579cb68cd3d5508dbedcf9f2f18a435b3683d964c3147bee7f75da73b2ee"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "76cb0309c4d1db3f65ae9a525396d93bd32063dfca1417c60337f195179fde8f"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "6e5546c955eef219fb0dcae720b797937e38fec097ea3d0607594613f5ab6866ddec8c0c37a4192a3ef5b7642e7d5e79b85058298a1b0397576233e055cf5ab2"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.thymeleaf/thymeleaf-spring5@3.0.15.RELEASE?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "http://www.thymeleaf.org"
+        },
+        {
+          "type" : "distribution-intake",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2"
+        },
+        {
+          "type" : "vcs",
+          "url" : "scm:git:git@github.com:thymeleaf/thymeleaf-spring.git"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.thymeleaf/thymeleaf-spring5@3.0.15.RELEASE?type=jar"
+    },
+    {
+      "publisher" : "The THYMELEAF team",
+      "group" : "org.thymeleaf",
+      "name" : "thymeleaf",
+      "version" : "3.0.15.RELEASE",
+      "description" : "Modern server-side Java template engine for both web and standalone environments",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "60c7ebe364a6b704ddf0348476a438ea"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "13e3296a03d8a597b734d832ed8656139bf9cdd8"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "9ea400b29d938eec670684eaa706a4fc11cd6c6ba58fd39b8ea9e13cb0177d75"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "e88a93caff7a153c26bc03c596a55b174e9eb5f10ce79c5293dec6f7c7f910150c0f2e7e523c79395a5eb4290ba5705cd378ea24cb010352fa4fc8572b1fa751"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "a29b4451a3e6453acbe61f49dc0c1f02a3795d3d6f0115df6e4300697e6f18ee3601260dbb3671e04adcf09f8e2297fb"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "4e1b81af85aa55fb5181cd3f263dd5e7ecc9dff65ed7b1321027c687de68f6aac1c3af21a86b38a8d3d5eb22d618a2ea"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "b34a4ec47482923cdec326d10c76c89a17b55041b9d30ad98b6273f428155419"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "73574c4cb7aae72294d192b9977ab1cbd080f7891d2349b7d45b6a5a590168ae438c966a8cd21880b361dcccffdb3f7c483830f70572b0008307f2e6ae53b7d8"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.thymeleaf/thymeleaf@3.0.15.RELEASE?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "http://www.thymeleaf.org"
+        },
+        {
+          "type" : "distribution-intake",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2"
+        },
+        {
+          "type" : "vcs",
+          "url" : "scm:git:git@github.com:thymeleaf/thymeleaf.git"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.thymeleaf/thymeleaf@3.0.15.RELEASE?type=jar"
+    },
+    {
+      "publisher" : "The ATTOPARSER team",
+      "group" : "org.attoparser",
+      "name" : "attoparser",
+      "version" : "2.0.5.RELEASE",
+      "description" : "Powerful, fast and easy to use HTML and XML parser for Java",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "546b814a33d40124427225d6d1df8fd2"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "a93ad36df9560de3a5312c1d14f69d938099fa64"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "d4015d56147f696ed0a90078675bc940529f907e7b2dfc1fad754e8033da8796"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "91b2eaadab67420252e47e52b4460ec13bb8c38a3a9b89a924974a4e2e411f0537a758e924800e4355b83aae5db6925f7e002fb5e0200735c69910d56b216524"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "34555574940d91fea7d83b57f82479091789f113d75813225fe1bd4040f4c98bc259d0fd4544f44181b462bca1554b50"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "99045ffa7ccb7bdce7f0186239b6d6b8bb205c07051c509fe2232d84ce5830f6c392266bc614d87f864e8910b0a6f186"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "6c7ed8d6ffb74f247dab1582f1f03de6adf28246c6957292a5cdc3edbd153b24"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "41e8040d0dcf7adc5ebd3c2bfa04026d8b404f23d25982eb50c885fc7152e3f48f68aa7b095f0b92e985cafee517b789deab9891c83aaeda090b42056bdfdb69"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.attoparser/attoparser@2.0.5.RELEASE?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "http://www.attoparser.org"
+        },
+        {
+          "type" : "distribution-intake",
+          "url" : "http://oss.sonatype.org/service/local/staging/deploy/maven2"
+        },
+        {
+          "type" : "vcs",
+          "url" : "scm:git:git@github.com:attoparser/attoparser.git"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.attoparser/attoparser@2.0.5.RELEASE?type=jar"
+    },
+    {
+      "publisher" : "The UNBESCAPE team",
+      "group" : "org.unbescape",
+      "name" : "unbescape",
+      "version" : "1.1.6.RELEASE",
+      "description" : "Advanced yet easy-to-use escape/unescape library for Java",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "d95ed94e1624e307a1958ee105ccbf39"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "7b90360afb2b860e09e8347112800d12c12b2a13"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "597cf87d5b1a4f385b9d1cec974b7b483abb3ee85fc5b3f8b62af8e4bec95c2c"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "6918e9579b06721942fdcd91e401f5b996fb4eac13056dbafdf594661f355a34874eb5266784bc2c4f82df9fdd9e219d71a96f52945a354f01665f85f8166bb3"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "1b808b67c784b69afea64364ba4c0d433c7f042c512f5c18f07d5388fe7ac4741913f696424bd8fbde147383cfb3d8f9"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "6525bd20a12ff43a0089c0d59369574ae6c01e2b4b1aacf466847d4433ae403db08404a9b59be397c3034f972bcd6b06"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "a190c9bedccff959d08db12fe7080437fb4e98f05516b39d6540be718e151cc6"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "5d7b5edc0c2a0d47c9625936c14b4122330b96cdf54260fe2a6468289c2f4cbc4ee19770c1144acfa702f2f058a81544b4aea9258fe0e15166a1a331736d7b77"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.unbescape/unbescape@1.1.6.RELEASE?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "http://www.unbescape.org"
+        },
+        {
+          "type" : "distribution-intake",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2"
+        },
+        {
+          "type" : "vcs",
+          "url" : "scm:git:git@github.com:unbescape/unbescape.git"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.unbescape/unbescape@1.1.6.RELEASE?type=jar"
+    },
+    {
+      "publisher" : "The THYMELEAF team",
+      "group" : "org.thymeleaf.extras",
+      "name" : "thymeleaf-extras-java8time",
+      "version" : "3.0.4.RELEASE",
+      "description" : "Modern server-side Java template engine for both web and standalone environments",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "01420fcda7481663f967836c440f9bc5"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "36e7175ddce36c486fff4578b5af7bb32f54f5df"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "c07690c764329afd148a4134980d636911390a3fda45f6c6ae46517e4b4444d3"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "e5e35400eb6ed593e20b9718748eb9568b2af7e3e1141c0e0582b82f3b4dfb8d40991b988806ed9b8b3cf1e7f11dd7106ad524fdf7925f7b1836f1be183d4ee5"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "21930e0f55834e8636b98fe10caf775452bd5251560ef2110e78ae2e0a5b7f5a3378677189d34e01e4c58f5fc04841af"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "2f5166979a71b75b44831035b22443d7bef7ad7d6825e3f163841a082f1bc4631ba58e81aac2833f4d35d74cc4a2defb"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "614bbb1c04b2d3c51a10e9d49c23fb00fcb6652e0fbdedb0585a5bd4b923ee18"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "e4738babfee412ed3ea21ac735155f0880d6f20879f84f65e6388c5ef8a2fc83774f4fcedb6899e393b439ff1f983a91d39d78eeece2e96e401a9dc8a187c52e"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.thymeleaf.extras/thymeleaf-extras-java8time@3.0.4.RELEASE?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "http://www.thymeleaf.org"
+        },
+        {
+          "type" : "distribution-intake",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2"
+        },
+        {
+          "type" : "vcs",
+          "url" : "scm:git:git@github.com:thymeleaf/thymeleaf-extras-java8time.git"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.thymeleaf.extras/thymeleaf-extras-java8time@3.0.4.RELEASE?type=jar"
+    },
+    {
+      "publisher" : "Eclipse Foundation",
+      "group" : "jakarta.xml.bind",
+      "name" : "jakarta.xml.bind-api",
+      "version" : "2.3.3",
+      "description" : "Jakarta XML Binding API",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "61286918ca0192e9f87d1358aef718dd"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "48e3b9cfc10752fba3521d6511f4165bea951801"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "c04539f472e9a6dd0c7685ea82d677282269ab8e7baca2e14500e381e0c6cec5"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "adf6436a7a9dc6f64b97127861d7a89b78e82bea67f72bda800ef285163adcd84dbf006f679108a2a8c2eed013e0b771da2354087e0845479ff2b6318b881442"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "bad8b9f52bf7a7e1d3974cb305a69c093fb32d2131539c18d34e471e3ec32bdd9dd136bb4b38bb14d84e99c562f208c7"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "8131aaf65f996cfa2c3f7d406caab3acf3e6650bcbbcd5595f8a457a211810ff110c1923876e068831a07388ddc26f33"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "a9e4179a6bfa8b363b9fd4f32f8892c4a7954ed1695d3f33ccef73ceffcaa1d4"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "9ecbc0f4aa9cff28d519cbf74c8234b5180ae6ff0d6de4efe2de126b3251d466a5ddb878e70b9968095a843c82721c93a4dec53bfe09e3700f4cfe2e38bcac0a"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "BSD-3-Clause"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/jakarta.xml.bind/jakarta.xml.bind-api@2.3.3?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://github.com/eclipse-ee4j/jaxb-api/jakarta.xml.bind-api"
+        },
+        {
+          "type" : "distribution-intake",
+          "url" : "https://jakarta.oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/eclipse-ee4j/jaxb-api/issues"
+        },
+        {
+          "type" : "mailing-list",
+          "url" : "https://dev.eclipse.org/mhonarc/lists/jaxb-dev"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/eclipse-ee4j/jaxb-api.git/jakarta.xml.bind-api"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/jakarta.xml.bind/jakarta.xml.bind-api@2.3.3?type=jar"
+    },
+    {
+      "publisher" : "Eclipse Foundation",
+      "group" : "jakarta.activation",
+      "name" : "jakarta.activation-api",
+      "version" : "1.2.2",
+      "description" : "Jakarta Activation API jar",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "1cbb480310fa1987f9db7a3ed7118af7"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "99f53adba383cb1bf7c3862844488574b559621f"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "a187a939103aef5849a7af84bd7e27be2d120c410af291437375ffe061f4f09d"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "e3d846ff5f62ad9fef514f0726846c63d4aa74b2bb8f60c76258dba37701f83ae75872401071bf40da40697d43a8a6e36d08fa4ef39fe70797fb6f2b1712599f"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "3e25702596eca7dd48f904b3985d64b4b394d162d3884a907d8b2ee647542808713a42a02f0eeff2c07518a206cc91cf"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "07196bf6c1ba4fe3e14e7690b521d3a156ee136a0b34d93f7a20d485c528c25ed5eeaec013172b08bdc63800fa94fe5d"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "5010f77dbc8c2a28269c7b5b662732ec4a01806f3af9af0b5a12882670303b6e"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "6e63931ef5638e4919b210ef3fffc731d3b91a34bd88cf4b4410e583e28d9e8652377b74dbdb63ba4b7b11b68ded509200737527412984c9d5bc6e5b4b938993"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "BSD-3-Clause"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/jakarta.activation/jakarta.activation-api@1.2.2?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://github.com/eclipse-ee4j/jaf/jakarta.activation-api"
+        },
+        {
+          "type" : "distribution-intake",
+          "url" : "https://jakarta.oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/eclipse-ee4j/jaf/issues/"
+        },
+        {
+          "type" : "mailing-list",
+          "url" : "https://dev.eclipse.org/mhonarc/lists/jakarta.ee-community/"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/eclipse-ee4j/jaf/jakarta.activation-api"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/jakarta.activation/jakarta.activation-api@1.2.2?type=jar"
+    },
+    {
+      "publisher" : "Spring IO",
+      "group" : "org.springframework",
+      "name" : "spring-core",
+      "version" : "5.3.22",
+      "description" : "Spring Core",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "8f768c0706314fb9c71cd5db24a6225a"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "661fc01832716c7eedebf995c6841b2f7117c63d"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "6e97fb95215c583b06098c0a73d27237c6165ccd4f8103e2ded40303382bcba3"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "bc3ca0449e24fa0acdc165bba7d7e44adeac326a022a07de89044001c447a337f5eb8105d76872684a75f5d8e72822011367e79bd2f81ba185678883ddd772a2"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "fd8e922517794d3f1acd7b37da1450594a7eaf92f0148c513b2714e28bc19c0f174af33993b093e90e8a851abe2328e6"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "1ec6036d92de7d4090005e89e9460f52b392ef10fe8c9129aba6fab2489c21bf45db65ee60dc66b7adae88b4a7d8e2dc"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "891916b8b4fb95c0041e259fdabc1cdc9d65ae32c916e2a0a3427fe4b50f9980"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "df2fc08bba65aa8c13f7cd52e9dd72ea99dbdc0a3ace4c62d95d59a243dfcf27a62fc425add0d8f36ecfbc7e91a0bcf2b653b86ad961498dfa74a3ce86dce725"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.springframework/spring-core@5.3.22?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://github.com/spring-projects/spring-framework"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/spring-projects/spring-framework/issues"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/spring-projects/spring-framework"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.springframework/spring-core@5.3.22?type=jar"
+    },
+    {
+      "publisher" : "Spring IO",
+      "group" : "org.springframework",
+      "name" : "spring-jcl",
+      "version" : "5.3.22",
+      "description" : "Spring Commons Logging Bridge",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "ee2f0e6c61acc47fa33c908177c921c0"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "811ace5e5eb379654ed96fd7844809db51af74a5"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "9850007771da9a266a1c8176a7a8387cc33603f5f92dc753afc846dec125c880"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "e4512c191cfb926839aebddea52a214f8571b9062825bda5ad45c7a589fb5e345131f3dac6d44ffb4eab9704036676efe6d58e75d294e7d26deb5de853f22978"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "ded00cbc79e55bff47528595d20c36146b0b0d6aced22b72342c27aad1b3237dfb7542dbd056eeaec8fc1d92f5a0e535"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "57d31acfbedb31488cc7073e6218a084b5d65e558878762a94dd792fa816fc16843dc9f0628150b216f17ab5f133204e"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "1e82255ab13f7488754caf3435d93d7593e944db55b992500c6e58db2dfcde00"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "1eddaca8eb29cef32c1450093011fb678e4fa7ac878d234a6041c54f34b24b53ccc41c2f9d6b7b0fb69250337477364f5691ad7916a95952db7a76eefada8a15"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.springframework/spring-jcl@5.3.22?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://github.com/spring-projects/spring-framework"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/spring-projects/spring-framework/issues"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/spring-projects/spring-framework"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.springframework/spring-jcl@5.3.22?type=jar"
+    },
+    {
+      "group" : "com.h2database",
+      "name" : "h2",
+      "version" : "2.1.214",
+      "description" : "H2 Database Engine",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "93628fb706e682dd989f697394039025"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "d5c2005c9e3279201e12d4776c948578b16bf8b2"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "d623cdc0f61d218cf549a8d09f1c391ff91096116b22e2475475fce4fbe72bd0"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "fedc464dee11077ea3e95149b3c1a1420d6e432c940ccb8c368633821b29c0e401b711d45f819d1cc3755a54ad05fdd0e8bb6b17853dd15539613f5e2765f359"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "a53154e9f52e73228c27602b05f3cc24939dad90cd769f3ba9d3c498b21d53dde054f85f56286a043a941b68ea3ca7fe"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "ac9b13665daa9b745ac1f2584f97623f8323b9966d272c515e51e502f063f0ef2103b2d98bf37e8c35c728a0a597c6c2"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "58e3dd539432b47c8555edf19ef12d78537b9c2f2d775594297ae7a57c97557f"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "30cb7b5fd7bebebfb258a96a6ad5e5d59f68fe16ecf6e5e985dc5b3e7a7319bd5d675e03f7d69a548be07351ba3b25946facbdc3955b8f0bc30edc5c7cc5fd84"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "MPL-2.0"
+          }
+        },
+        {
+          "license" : {
+            "name" : "EPL 1.0",
+            "url" : "https://opensource.org/licenses/eclipse-1.0.php"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/com.h2database/h2@2.1.214?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://h2database.com"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/h2database/h2database"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/com.h2database/h2@2.1.214?type=jar"
+    },
+    {
+      "publisher" : "Oracle Corporation",
+      "group" : "mysql",
+      "name" : "mysql-connector-java",
+      "version" : "8.0.30",
+      "description" : "JDBC Type 4 driver for MySQL",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "ad7ef879830dbf17c7a73bf03b34f6fc"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "b26dd6e4e917d3d4726c34d09d2fd67df7c1dd37"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "b5bf2f0987197c30adf74a9e419b89cda4c257da2d1142871f508416d5f2227a"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "8120c80ad5c23cc5c2fbcd68180d345ce506f637fd2bffc696ddeec2ec37cb570a419fe5b4aad9d53907575ef3fe4f95bcaa4d7655ebea463c4d5b1b9db89759"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "9d706dc7956a556592720be11dd88a3652fdb26f0624654b47523e391a7a14ba7416585e144e27995356e904a65e21a3"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "4c047aadb4fba5a1985a274c9225f230720c457c08f0cd9391a1e1b0a32651825c00fc501a42b2ef58279aa841510d03"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "4322f08ae3e7a33f73d4f140b7259ae0752eeddf0e6a736b49989870468e83a5"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "55d7d5d62f13d13ff9981f6625c53828111abd59c19f7f98836e21d92d904d8e0417302a4805b9a1721a8aabd6f54079ee2bdeb2776e68f7cfbc5af393c774ff"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "name" : "The GNU General Public License, v2 with FOSS exception"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/mysql/mysql-connector-java@8.0.30?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "http://dev.mysql.com/doc/connector-j/en/"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/mysql/mysql-connector-j"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/mysql/mysql-connector-java@8.0.30?type=jar"
+    },
+    {
+      "publisher" : "PostgreSQL Global Development Group",
+      "group" : "org.postgresql",
+      "name" : "postgresql",
+      "version" : "42.3.6",
+      "description" : "PostgreSQL JDBC Driver Postgresql",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "8693d79c6088ab05026dfcb73a811a48"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "98e509e29657cd3633d93bc05ae41ff71fbb79d1"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "43666128a1d1d6b36870b858973a170d3fa6293c969684fe88f42a71140293a0"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "e557147c748e0b6ec21fa772dc48ebda87fb689e57d26cd85fb02d4a9cd09cb6f07e0f17af0746b607b1fe4700ba640fb8de963e87d573b407a013e24163d1d0"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "012a025865b5fcf8df6aa5f1dcf97bc734e8cd1ec301ac07d261cf87b71dcad0671ea514dc8f832e5d2eafe26e6b4bfd"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "444a6223f192127fef300dde39e6a2aff3d24ead2ab01eccd38c4a8e05aba0fdb896221195f6d380b6c483e42b0416a5"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "9ef1375fbace6048c0dc109e506a7c2dcb98d287ef6d207da0034fe7b11af991"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "dac0989440ef4a86f9e339d65f4eac33c391669e0c5d37dbbf29aba13fadd289f81e66606371089a0a4ec37b2c4c845f3800580440ebc61a0d7921f1501b662e"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "BSD-2-Clause",
+            "url" : "https://opensource.org/licenses/BSD-2-Clause"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.postgresql/postgresql@42.3.6?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://jdbc.postgresql.org"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/pgjdbc/pgjdbc/issues"
+        },
+        {
+          "type" : "mailing-list",
+          "url" : "https://www.postgresql.org/list/pgsql-jdbc/"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/pgjdbc/pgjdbc"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.postgresql/postgresql@42.3.6?type=jar"
+    },
+    {
+      "group" : "org.checkerframework",
+      "name" : "checker-qual",
+      "version" : "3.5.0",
+      "description" : "Checker Qual is the set of annotations (qualifiers) and supporting classes used by the Checker Framework to type check Java source code. Please see artifact: org.checkerframework:checker",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "4464def1ed5c10f248ebfe1bccbedf1a"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "2f50520c8abea66fbd8d26e481d3aef5c673b510"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "729990b3f18a95606fc2573836b6958bcdb44cb52bfbd1b7aa9c339cff35a5a4"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "407d0ac59b02cbef7d93f25c8b287cd587232aa5ddfee6d2c7ba34d712565b0a5adfe52b5daa20d3e6c3ab1e7a5f8b08698078d9179185a1b35ada1eb92213bf"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "01fb1d7a7440f807b2bdb697c709dfa5897edc0755152c0fef465cf77dd820623fccb410ad033e3d52d4b0bc57409ecf"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "626beff2173578c3a2ad732c81c48a9b091c9ffdea7d50f4b812fd14cd8299ab7a726b052808490b1022faca69aa6e91"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "4fbe95b196e75e549f66831e9b1f8f46cfe1793f4fda350857f5f24349d74af1"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "2c84365b1fcd16a765e49c5d8f30f28c3fe7cfe868ac32be726d8b9351c9053ffea23cfa1db9fb5c59c9928d22ad01c3c894d798e115bc446447228c7c4b24c6"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "MIT"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.checkerframework/checker-qual@3.5.0?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://checkerframework.org"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/typetools/checker-framework.git"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.checkerframework/checker-qual@3.5.0?type=jar"
+    },
+    {
+      "group" : "javax.cache",
+      "name" : "cache-api",
+      "version" : "1.1.1",
+      "description" : "Sonatype helps open source projects to set up Maven repositories on https://oss.sonatype.org/",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "dfdac9358e140e61c574abb1ada84dc9"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "c56fb980eb5208bfee29a9a5b9d951aba076bd91"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "9f34e007edfa82a7b2a2e1b969477dcf5099ce7f4f926fb54ce7e27c4a0cd54b"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "7e2c2e421c46d66f35ae0c107c31ae28606562190871655efd38c60b335a10b1770134f88c8aada5a389e9e364be885713fe7d0464c2a9fbea06ec1102b2c3e5"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "3740a5ddb6bf6d1627190fbabf06ffc19fb84a488c120ebf1bbc6407971905c7f415310a17c8db77ee90d09cb2301d3d"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "49c3aca710ab2ad62e4610ad0f3b76338079aa49e90e84cb18b59ced56caf9f6e2bc855e9900cb1b7748a1f3e0d160e2"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "ed71d13b59b8ebba5fb3f2f42da03e29d1fdaefef8fde375794a6598fdb702be"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "8b93ce37a0ea13bcb8f35a0237307f7b232c178d11e452d02c4383dbd51531eeb4a3c722778dfb95637412e6451a132f6031f0f4e3d51928a6b857160269dec0"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/javax.cache/cache-api@1.1.1?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://github.com/jsr107/jsr107spec"
+        },
+        {
+          "type" : "distribution-intake",
+          "url" : "http://oss.sonatype.org/service/local/staging/deploy/maven2"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/javax.cache/cache-api@1.1.1?type=jar"
+    },
+    {
+      "publisher" : "Terracotta Inc., a wholly-owned subsidiary of Software AG USA, Inc.",
+      "group" : "org.ehcache",
+      "name" : "ehcache",
+      "version" : "3.10.0",
+      "description" : "End-user ehcache3 jar artifact",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "29e7d123ba8caa52888adff98afd9e1c"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "7dbd8976ae8087f5db27be48abd4a238fce52765"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "3b8c765f23665ae1296a41d711825abfbc18fde5de14e383ef7144023bb4ff7e"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "223964f54a067e9d5f1a123a462d5aaf89c9db7e370ba6d4599420cfabd3fdd461d68b736872a03a2ade0a39519420eb9767bd89eacca32a526c8a670a881fd6"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "10b1a2ccc2fee4724f0dc8a0a75c3839251ada7c5000b720d1c502fb8b9a11cd6b79bbd99e61aee526ef32e96be9f231"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "576d8d9a2f898aafc781c4e0419db6ccc4beb89a5eb8bee622dc51fb99e6bc1a3034360191f0705d042386cfa90ce069"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "e6923696025a6deed43a7e65f52033c5cf460a4cf4ad55d427e1cbac0121b5b9"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "11ed78118ca42acf3e798a7cfbf11ccc3865eed90a8e76e6cbc7e9b444889299ba2c1d44389f2201ce27d30d2dde4f6e878123f829bba40fa43f3a4bb0148e74"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.ehcache/ehcache@3.10.0?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "http://ehcache.org"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/ehcache/ehcache3/issues"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/ehcache/ehcache3"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.ehcache/ehcache@3.10.0?type=jar"
+    },
+    {
+      "publisher" : "QOS.ch",
+      "group" : "org.slf4j",
+      "name" : "slf4j-api",
+      "version" : "1.7.36",
+      "description" : "The slf4j API",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "872da51f5de7f3923da4de871d57fd85"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "6c62681a2f655b49963a5983b8b0950a6120ae14"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "d3ef575e3e4979678dc01bf1dcce51021493b4d11fb7f1be8ad982877c16a1c0"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "f9b033fc019a44f98b16048da7e2b59edd4a6a527ba60e358f65ab88e0afae03a9340f1b3e8a543d49fa542290f499c5594259affa1ff3e6e7bf3b428d4c610b"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "2b14ad035877087157e379d3277dcdcd79e58d6bdb147c47d29e377d75ce53ad42cafbf22f5fb7827c7e946ff4876b9a"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "3bc3110dafb8d5be16a39f3b2671a466463cd99eb39610c0e4719a7bf2d928f2ea213c734887c6926a07c4cca7769e4b"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "ba2608179fcf46e2291a90b9cbb4aa30d718e481f59c350cc21c73b88d826881"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "14c4edcd19702ef607d78826839d8a6d3a39157df54b89a801d3d3cbbe1307131a77671b041c761122730fb1387888c5ec2e46bdd80e1cb07f8f144676441824"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "MIT",
+            "url" : "https://opensource.org/licenses/MIT"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.slf4j/slf4j-api@1.7.36?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "http://www.slf4j.org"
+        },
+        {
+          "type" : "distribution-intake",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/qos-ch/slf4j/slf4j-api"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.slf4j/slf4j-api@1.7.36?type=jar"
+    },
+    {
+      "publisher" : "Eclipse Foundation",
+      "group" : "org.glassfish.jaxb",
+      "name" : "jaxb-runtime",
+      "version" : "2.3.6",
+      "description" : "JAXB (JSR 222) Reference Implementation",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "29acad12b7cdd22b2a5ab66cd7439d48"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "1e6cd0e5d9f9919c8c8824fb4d310b09a978a60e"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "cd87d4b98a8bec1d237aed61472ef4adb6a8bb0515cbde1fd62fdd9781c16770"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "8e8042f4a2a45f3520ce6376d826c0445a54509a728f9f61b274c2e2d92d242bfabfba112994d0df56f59f58c48e4069fb2dabf0fcc67208e651597de5eeaa98"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "6c3cfac49412ee125c0183e39ef751b8a7db04f02133ca6e039259708d2bd36df88bca3163672c8ab809cca9824e8d7e"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "3a0e2fbe2231fb39ae58afc52ad6dabf3cb932d4b56116f5ed3697b57bd0970c915e1f2b14df48576277c50ebb055a3b"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "00c4b10fb5581894c010618d4af73b821fbc262d883e5e1089438efa72243668"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "f5657b09370ecd381e76148b52fd8aa8e904f09424f2c7df5307b11ac0403db885d8a82e50002047c5be4c532c8f5778bd11833beebef3ddfe02fbf2fd35b464"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "BSD-3-Clause"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.glassfish.jaxb/jaxb-runtime@2.3.6?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://eclipse-ee4j.github.io/jaxb-ri/"
+        },
+        {
+          "type" : "distribution-intake",
+          "url" : "https://jakarta.oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/eclipse-ee4j/jaxb-ri/issues"
+        },
+        {
+          "type" : "mailing-list",
+          "url" : "https://accounts.eclipse.org/mailing-list/jaxb-impl-dev"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/eclipse-ee4j/jaxb-ri.git/jaxb-runtime-parent/jaxb-runtime"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.glassfish.jaxb/jaxb-runtime@2.3.6?type=jar"
+    },
+    {
+      "publisher" : "Eclipse Foundation",
+      "group" : "org.glassfish.jaxb",
+      "name" : "txw2",
+      "version" : "2.3.6",
+      "description" : "TXW is a library that allows you to write XML documents.",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "dd02e61e4662e6461f0c21b08e721021"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "45db7b69a8f1ec2c21eb7d4fc0ee729f53c1addc"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "f8bc249d22ad950257c373aea80c2f16f18f5eb4d557bdb2660bf5e1f1e84776"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "468cd89821480364a49f73f1774383fd483fd8273d373601a4867b37267f125c3fdf3ffd8a73a114408699137c469c02e47f94b80c7d21df236b4a187d12680d"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "02c99a070c038081922bdae47cd9e739045342b223c55204716bba9f81eca971ed1313eab8bb103dc596bfd7b84a6b72"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "e63ebe6d86a51506c45b430c8a71d80ac0fa95f99692a30697468b242ccd5c818f5d4aaf967e049797fee704a92307db"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "585be97a69d2a94b6647330ac36b3d5b2389eadfb92138f2b80a3e8c3bcc4b63"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "2e7ed6f7267f7e4eb0c0b0e89f845fcd253eec4ab1fa66fd915b7a4bd738e881c9e8f801af17dbbbfbc4311409f0fad9737780693a1018582e307a3293d27405"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "BSD-3-Clause"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.glassfish.jaxb/txw2@2.3.6?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://eclipse-ee4j.github.io/jaxb-ri/"
+        },
+        {
+          "type" : "distribution-intake",
+          "url" : "https://jakarta.oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/eclipse-ee4j/jaxb-ri/issues"
+        },
+        {
+          "type" : "mailing-list",
+          "url" : "https://accounts.eclipse.org/mailing-list/jaxb-impl-dev"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/eclipse-ee4j/jaxb-ri.git/jaxb-txw-parent/txw2"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.glassfish.jaxb/txw2@2.3.6?type=jar"
+    },
+    {
+      "publisher" : "Eclipse Foundation",
+      "group" : "com.sun.istack",
+      "name" : "istack-commons-runtime",
+      "version" : "3.0.12",
+      "description" : "istack common utility code",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "1952bd76321f8580cfaa57e332a68287"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "cbbe1a62b0cc6c85972e99d52aaee350153dc530"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "27d85fc134c9271d5c79d3300fc4669668f017e72409727c428f54f2417f04cd"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "af36b11cc0d82b7f62c64941f4e7d441d25cb9f3c4b3e08753d038c388e5a09364b5dac9127f29a9b8df6d96034133caadab6d74371077478d2f301605913460"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "ad8ba1f6538e087915b1e7fbf4a7a60b006ebecc4ab52986c10dfe88ae11ae7eb6e1f302bee06f70b16ec316f001375b"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "2207c7e1570860d6300ef3157905498efaf26ba85566b053495f583b20c755cc07d6855b2d79136ab4d6544635e39f4d"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "50a425e524a6ee81110ecd86190d039a84d46aa3c45855310fe4f95abba3c21e"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "286997280ee0885c456686cf91c601e600106138f39eb81fc27381868f7ede0d1521cdf22c420331b1a961ed2f1ba1887a9ae05073f4364e3ffc297f40f0de53"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "BSD-3-Clause"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/com.sun.istack/istack-commons-runtime@3.0.12?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://projects.eclipse.org/projects/ee4j/istack-commons/istack-commons-runtime"
+        },
+        {
+          "type" : "distribution-intake",
+          "url" : "https://jakarta.oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/eclipse-ee4j/jaxb-istack-commons/issues"
+        },
+        {
+          "type" : "mailing-list",
+          "url" : "https://dev.eclipse.org/mhonarc/lists/jaxb-impl-dev"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/eclipse-ee4j/jaxb-istack-commons/istack-commons-runtime"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/com.sun.istack/istack-commons-runtime@3.0.12?type=jar"
+    },
+    {
+      "publisher" : "Eclipse Foundation",
+      "group" : "com.sun.activation",
+      "name" : "jakarta.activation",
+      "version" : "1.2.2",
+      "description" : "Jakarta Activation",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "0b8bee3bf29b9a015f8b992035581a7c"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "74548703f9851017ce2f556066659438019e7eb5"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "02156773e4ae9d048d14a56ad35d644bee9f1052a791d072df3ded3c656e6e1a"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "8bd94a4370b827e3904f31253b022e5c1851896d3b616ca7daebfef259238cedc56d4ced32c74f24a13c3e2295b0ea012af5d04656b7f713cc53a2f18d5e2cf7"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "1cb0aff8b73ba52a9931b2cf13c75a1ce6665fb826bf97ede66db75c532136aa189fb53a1925e62b6eef572309ef3b9a"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "83801332576d931f4091ba65ea240d49c23e3b93dae939ce2eed63de943f80f251a4347638b99900de5b831796b12590"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "5363211b59dfaff6e1973e93548e5e4062189c6d0f43d7802627ebeb7b7ff37d"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "0c7b62a3432b19ffad02eafffc7e598391cd32b1313d075f94cda09913402770b4ba2314716625571f266431067229c93cec36e17c3ea598623542988634ca0a"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "BSD-3-Clause"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/com.sun.activation/jakarta.activation@1.2.2?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://github.com/eclipse-ee4j/jaf/jakarta.activation"
+        },
+        {
+          "type" : "distribution-intake",
+          "url" : "https://jakarta.oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/eclipse-ee4j/jaf/issues/"
+        },
+        {
+          "type" : "mailing-list",
+          "url" : "https://dev.eclipse.org/mhonarc/lists/jakarta.ee-community/"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/eclipse-ee4j/jaf/jakarta.activation"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/com.sun.activation/jakarta.activation@1.2.2?type=jar"
+    },
+    {
+      "group" : "org.webjars.npm",
+      "name" : "bootstrap",
+      "version" : "5.1.3",
+      "description" : "WebJar for bootstrap",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "3df1c150436df8659cfa05fa231e0910"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "884629733aed9d55a20b8db921335849abb6732f"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "fec359661b76788128e2ce0b509272eb1151126824b6d95f665e53a58a5fc501"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "bff68d5433af6973b50d6399ae67b0bfaeee22dade7a667e3bf92b52aaf6dc20c7c3b6fdcc1c25f40a2c181d6267ab29ca8590c05e31a307e36c4d3fa462144b"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "cf2109654f924573ec4aaf7bb31301254e40b355679f5d3da0a1ed03d164e4459ae8337c00f2368d124e3ef194708781"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "ca1c90e380c647598e602ce9be5cd31a88b42b59033494122a4d5d89ae73b447aa2702ad0cb3bd69af019fc0dec344bc"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "9850f135d21dfdf98a3cc46397f66a6da4f8f973983d2377f07d74c2392effbe"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "57fe1058d4ea9d2159a69c205444af5bde2e540077983a4af9ff7c795c2e67576a1f077b69d5d4f31db20c23c606e9b2f0a09333b44a34d9f16c17373a3f4ae6"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "MIT",
+            "url" : "https://opensource.org/licenses/MIT"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.webjars.npm/bootstrap@5.1.3?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://www.webjars.org"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/twbs/bootstrap/issues"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/twbs/bootstrap"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.webjars.npm/bootstrap@5.1.3?type=jar"
+    },
+    {
+      "group" : "org.webjars.npm",
+      "name" : "font-awesome",
+      "version" : "4.7.0",
+      "description" : "WebJar for font-awesome",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "d01d4fbc4870714c76341ca06ea80525"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "309276dbcb8afe0482a1698a78b081b918e0e445"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "d786751120afe993113902d3eaccb4f596cfd5c98583a2abd76f6a57a8af865a"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "d70796ec3ce97c137606c2b5b9f674336ab6a7e9908b0089b838f4ef9b42b3fa5800aef11a495ec44c82d5a15b6c7597bd75b78824dcc7ed181ca6412e4d9be9"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "cfa0790f78e863140a454385cd2d619de59e4a01fc2a1df9d2a59aa1e3829e3882b3590729d664e42478e6f8628ac958"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "f6789e70bcde46eec4db08b18203e84183ccbe952ceecb0f36974c647af0aeb03a1dac1a4f731b4fc4b8fd1eaedb5c7c"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "8026292f96b797582e60b953d1fc8a7326db0ee3ee136922f15cfdba373db347"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "b4edd32c8a74d4fafa970a01fc3256cbeea90f9c89ce94aa0206789cf08ea9c1f897f6c2b7615affd6202d03e9fdb835b07a50716503dd457a274c70e37f38a7"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "name" : "Openfont-1.1",
+            "url" : "https://spdx.org/licenses/Openfont-1.1#licenseText"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.webjars.npm/font-awesome@4.7.0?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "http://webjars.org"
+        },
+        {
+          "type" : "vcs",
+          "url" : "git+https://github.com/FortAwesome/Font-Awesome"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.webjars.npm/font-awesome@4.7.0?type=jar"
+    },
+    {
+      "publisher" : "Pivotal Software, Inc.",
+      "group" : "org.springframework.boot",
+      "name" : "spring-boot-devtools",
+      "version" : "2.7.3",
+      "description" : "Spring Boot Developer Tools",
+      "scope" : "optional",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "c15cf64bd43d6f0e1a367fc26aab7704"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "ea46ce1fc8c0581f2455dcc43a11768660d87388"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "a9bfb3b438f7c1b0c666c033803b7a8d5b607f526e2ef47daa3f7bd72a469071"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "8443d117fcfe06d60b68b890c9a22771a47c77a9428e7c7519f8c30002a5e662abd39c81d3ba1a0f112c30bacb3310f370af4b5ddcc47c6637b2e58c07d1a237"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "c508a02a7275ac8a9930da4f95f3b7a1627f58ab487e5de43f172b674cf57c472f9ce729170382e4501c42fd6f4f059e"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "a45a100b01e7124ce77765f714bafb30cc4246b4bf867d05b1f2c893501dfe7fe8bbb86fba9c366b7314cca6a3736c50"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "e442479718ac52c84f5c43e242a55ac042828775ccf8010b8db86a56740fa334"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "20e17e184b4f65975c5a5732cdb45152ec4738938b2f26c0b7e5825d00f7c63e4af1b3fb3d068bd3b83e0ec3a22c295e10f53d4b81ca98f2dd1aba5588d85b6c"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.springframework.boot/spring-boot-devtools@2.7.3?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://spring.io/projects/spring-boot"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/spring-projects/spring-boot/issues"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/spring-projects/spring-boot"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.springframework.boot/spring-boot-devtools@2.7.3?type=jar"
+    },
+    {
+      "publisher" : "Pivotal Software, Inc.",
+      "group" : "org.springframework.boot",
+      "name" : "spring-boot",
+      "version" : "2.7.3",
+      "description" : "Spring Boot",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "ac0034bdd663b8f79bbb876d29821427"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "3a8d641077565b7eaec3b2f91d5b83a6800f5895"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "b7e0a7ab7292a8827e34f86867a8fdf8354c7585c2db4fc6c802ede56fe07d3c"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "625436d3710bf80dc81fa47e5e9148e10a677733b4a2e5be9ab863ccdbd944c0fd5714b7427a4a12fd06e72741cc2db8c0b013cff879c0ef064927282b39e8a1"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "ff1d07b7d31b56a6f567e6a8dc44fc176a022dc2e1d46feb2a9b4ae77b22b7069a700944db9bc90e9e8528d83ff7941c"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "4dc092d53b9de209a890dffe7e43399efc38ee082221270f8982f882ae43b245989073d0971fbc38efb40efbbbeedcc1"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "8a3e5a2f4d628c4e44951b1ce2f1f2c1d1b8d62e74c3d4d314e41fd4cd94f2cc"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "32574d1caa708ef730787083fcc9d2f35845c3cc8d96bad1b23388b486e03400ef1ad826e3ac469d64fcbe81f5b452fa2f50aa18ab84fb637754063f3b39a565"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.springframework.boot/spring-boot@2.7.3?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://spring.io/projects/spring-boot"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/spring-projects/spring-boot/issues"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/spring-projects/spring-boot"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.springframework.boot/spring-boot@2.7.3?type=jar"
+    },
+    {
+      "publisher" : "Pivotal Software, Inc.",
+      "group" : "org.springframework.boot",
+      "name" : "spring-boot-autoconfigure",
+      "version" : "2.7.3",
+      "description" : "Spring Boot AutoConfigure",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "5b7ff135649bab33112ee1a590c24ad9"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "4c96169e8d71c9c41f07a40d011dbd41898180ac"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "a54b67cd971f856098e05ed13967596220a1898563a2552252234793e2fa8e63"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "5cf8bc76aaa3b8a6c5e3acf84555e5a326fa67f3391ad51a5853a43ba537174b3d19a813292bbf4110a95225b43ab8d96c1704aab74cec81fa3b595f165a0a84"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "8dfaa4bfa43f12f8497c72c7d9cbc45dd19762ac1ae2169283cdd81b616c5b810227a2ed03430f2be98fbd72d461f5ba"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "081f551d31a703353c0bb368a978c146a1c4edcfa96702dbe9322442784bcd2f9d95076b9f309ca3df306d4d05146a5e"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "e5bed6eba9a01fce9bea7c577d3bc158e96cef3aae7a41cb6933eb3cadcdef94"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "2dd4d92a7bcd4abfba948c956e50675ba34257cb6dc0ca9ecd89dd02b4cd89b5e04e3b7e37271ed25dbad058e65e6cab169d0516e42efb16540754eb97a386d4"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.springframework.boot/spring-boot-autoconfigure@2.7.3?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://spring.io/projects/spring-boot"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/spring-projects/spring-boot/issues"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/spring-projects/spring-boot"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.springframework.boot/spring-boot-autoconfigure@2.7.3?type=jar"
+    }
+  ],
+  "dependencies" : [
+    {
+      "ref" : "pkg:maven/org.springframework.samples/spring-petclinic@2.7.3?type=jar",
+      "dependsOn" : [
+        "pkg:maven/org.springframework.boot/spring-boot-starter-actuator@2.7.3?type=jar",
+        "pkg:maven/org.springframework.boot/spring-boot-starter-cache@2.7.3?type=jar",
+        "pkg:maven/org.springframework.boot/spring-boot-starter-data-jpa@2.7.3?type=jar",
+        "pkg:maven/org.springframework.boot/spring-boot-starter-web@2.7.3?type=jar",
+        "pkg:maven/org.springframework.boot/spring-boot-starter-validation@2.7.3?type=jar",
+        "pkg:maven/org.springframework.boot/spring-boot-starter-thymeleaf@2.7.3?type=jar",
+        "pkg:maven/com.h2database/h2@2.1.214?type=jar",
+        "pkg:maven/mysql/mysql-connector-java@8.0.30?type=jar",
+        "pkg:maven/org.postgresql/postgresql@42.3.6?type=jar",
+        "pkg:maven/javax.cache/cache-api@1.1.1?type=jar",
+        "pkg:maven/org.ehcache/ehcache@3.10.0?type=jar",
+        "pkg:maven/org.webjars.npm/bootstrap@5.1.3?type=jar",
+        "pkg:maven/org.webjars.npm/font-awesome@4.7.0?type=jar",
+        "pkg:maven/org.springframework.boot/spring-boot-devtools@2.7.3?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/org.springframework.boot/spring-boot-starter-actuator@2.7.3?type=jar",
+      "dependsOn" : [
+        "pkg:maven/org.springframework.boot/spring-boot-starter@2.7.3?type=jar",
+        "pkg:maven/org.springframework.boot/spring-boot-actuator-autoconfigure@2.7.3?type=jar",
+        "pkg:maven/io.micrometer/micrometer-core@1.9.3?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/org.springframework.boot/spring-boot-starter@2.7.3?type=jar",
+      "dependsOn" : [
+        "pkg:maven/org.springframework.boot/spring-boot@2.7.3?type=jar",
+        "pkg:maven/org.springframework.boot/spring-boot-autoconfigure@2.7.3?type=jar",
+        "pkg:maven/org.springframework.boot/spring-boot-starter-logging@2.7.3?type=jar",
+        "pkg:maven/jakarta.annotation/jakarta.annotation-api@1.3.5?type=jar",
+        "pkg:maven/org.springframework/spring-core@5.3.22?type=jar",
+        "pkg:maven/org.yaml/snakeyaml@1.30?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/org.springframework.boot/spring-boot@2.7.3?type=jar",
+      "dependsOn" : [
+        "pkg:maven/org.springframework/spring-core@5.3.22?type=jar",
+        "pkg:maven/org.springframework/spring-context@5.3.22?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/org.springframework/spring-core@5.3.22?type=jar",
+      "dependsOn" : [
+        "pkg:maven/org.springframework/spring-jcl@5.3.22?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/org.springframework/spring-jcl@5.3.22?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/org.springframework/spring-context@5.3.22?type=jar",
+      "dependsOn" : [
+        "pkg:maven/org.springframework/spring-aop@5.3.22?type=jar",
+        "pkg:maven/org.springframework/spring-beans@5.3.22?type=jar",
+        "pkg:maven/org.springframework/spring-core@5.3.22?type=jar",
+        "pkg:maven/org.springframework/spring-expression@5.3.22?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/org.springframework/spring-aop@5.3.22?type=jar",
+      "dependsOn" : [
+        "pkg:maven/org.springframework/spring-beans@5.3.22?type=jar",
+        "pkg:maven/org.springframework/spring-core@5.3.22?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/org.springframework/spring-beans@5.3.22?type=jar",
+      "dependsOn" : [
+        "pkg:maven/org.springframework/spring-core@5.3.22?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/org.springframework/spring-expression@5.3.22?type=jar",
+      "dependsOn" : [
+        "pkg:maven/org.springframework/spring-core@5.3.22?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/org.springframework.boot/spring-boot-autoconfigure@2.7.3?type=jar",
+      "dependsOn" : [
+        "pkg:maven/org.springframework.boot/spring-boot@2.7.3?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/org.springframework.boot/spring-boot-starter-logging@2.7.3?type=jar",
+      "dependsOn" : [
+        "pkg:maven/ch.qos.logback/logback-classic@1.2.11?type=jar",
+        "pkg:maven/org.apache.logging.log4j/log4j-to-slf4j@2.17.2?type=jar",
+        "pkg:maven/org.slf4j/jul-to-slf4j@1.7.36?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/ch.qos.logback/logback-classic@1.2.11?type=jar",
+      "dependsOn" : [
+        "pkg:maven/ch.qos.logback/logback-core@1.2.11?type=jar",
+        "pkg:maven/org.slf4j/slf4j-api@1.7.36?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/ch.qos.logback/logback-core@1.2.11?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/org.slf4j/slf4j-api@1.7.36?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/org.apache.logging.log4j/log4j-to-slf4j@2.17.2?type=jar",
+      "dependsOn" : [
+        "pkg:maven/org.slf4j/slf4j-api@1.7.36?type=jar",
+        "pkg:maven/org.apache.logging.log4j/log4j-api@2.17.2?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/org.apache.logging.log4j/log4j-api@2.17.2?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/org.slf4j/jul-to-slf4j@1.7.36?type=jar",
+      "dependsOn" : [
+        "pkg:maven/org.slf4j/slf4j-api@1.7.36?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/jakarta.annotation/jakarta.annotation-api@1.3.5?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/org.yaml/snakeyaml@1.30?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/org.springframework.boot/spring-boot-actuator-autoconfigure@2.7.3?type=jar",
+      "dependsOn" : [
+        "pkg:maven/org.springframework.boot/spring-boot-actuator@2.7.3?type=jar",
+        "pkg:maven/org.springframework.boot/spring-boot@2.7.3?type=jar",
+        "pkg:maven/org.springframework.boot/spring-boot-autoconfigure@2.7.3?type=jar",
+        "pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.13.3?type=jar",
+        "pkg:maven/com.fasterxml.jackson.datatype/jackson-datatype-jsr310@2.13.3?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/org.springframework.boot/spring-boot-actuator@2.7.3?type=jar",
+      "dependsOn" : [
+        "pkg:maven/org.springframework.boot/spring-boot@2.7.3?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.13.3?type=jar",
+      "dependsOn" : [
+        "pkg:maven/com.fasterxml.jackson.core/jackson-annotations@2.13.3?type=jar",
+        "pkg:maven/com.fasterxml.jackson.core/jackson-core@2.13.3?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/com.fasterxml.jackson.core/jackson-annotations@2.13.3?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/com.fasterxml.jackson.core/jackson-core@2.13.3?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/com.fasterxml.jackson.datatype/jackson-datatype-jsr310@2.13.3?type=jar",
+      "dependsOn" : [
+        "pkg:maven/com.fasterxml.jackson.core/jackson-annotations@2.13.3?type=jar",
+        "pkg:maven/com.fasterxml.jackson.core/jackson-core@2.13.3?type=jar",
+        "pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.13.3?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/io.micrometer/micrometer-core@1.9.3?type=jar",
+      "dependsOn" : [
+        "pkg:maven/org.hdrhistogram/HdrHistogram@2.1.12?type=jar",
+        "pkg:maven/org.latencyutils/LatencyUtils@2.0.3?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/org.hdrhistogram/HdrHistogram@2.1.12?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/org.latencyutils/LatencyUtils@2.0.3?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/org.springframework.boot/spring-boot-starter-cache@2.7.3?type=jar",
+      "dependsOn" : [
+        "pkg:maven/org.springframework.boot/spring-boot-starter@2.7.3?type=jar",
+        "pkg:maven/org.springframework/spring-context-support@5.3.22?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/org.springframework/spring-context-support@5.3.22?type=jar",
+      "dependsOn" : [
+        "pkg:maven/org.springframework/spring-beans@5.3.22?type=jar",
+        "pkg:maven/org.springframework/spring-context@5.3.22?type=jar",
+        "pkg:maven/org.springframework/spring-core@5.3.22?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/org.springframework.boot/spring-boot-starter-data-jpa@2.7.3?type=jar",
+      "dependsOn" : [
+        "pkg:maven/org.springframework.boot/spring-boot-starter-aop@2.7.3?type=jar",
+        "pkg:maven/org.springframework.boot/spring-boot-starter-jdbc@2.7.3?type=jar",
+        "pkg:maven/jakarta.transaction/jakarta.transaction-api@1.3.3?type=jar",
+        "pkg:maven/jakarta.persistence/jakarta.persistence-api@2.2.3?type=jar",
+        "pkg:maven/org.hibernate/hibernate-core@5.6.10.Final?type=jar",
+        "pkg:maven/org.springframework.data/spring-data-jpa@2.7.2?type=jar",
+        "pkg:maven/org.springframework/spring-aspects@5.3.22?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/org.springframework.boot/spring-boot-starter-aop@2.7.3?type=jar",
+      "dependsOn" : [
+        "pkg:maven/org.springframework.boot/spring-boot-starter@2.7.3?type=jar",
+        "pkg:maven/org.springframework/spring-aop@5.3.22?type=jar",
+        "pkg:maven/org.aspectj/aspectjweaver@1.9.7?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/org.aspectj/aspectjweaver@1.9.7?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/org.springframework.boot/spring-boot-starter-jdbc@2.7.3?type=jar",
+      "dependsOn" : [
+        "pkg:maven/org.springframework.boot/spring-boot-starter@2.7.3?type=jar",
+        "pkg:maven/com.zaxxer/HikariCP@4.0.3?type=jar",
+        "pkg:maven/org.springframework/spring-jdbc@5.3.22?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/com.zaxxer/HikariCP@4.0.3?type=jar",
+      "dependsOn" : [
+        "pkg:maven/org.slf4j/slf4j-api@1.7.36?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/org.springframework/spring-jdbc@5.3.22?type=jar",
+      "dependsOn" : [
+        "pkg:maven/org.springframework/spring-beans@5.3.22?type=jar",
+        "pkg:maven/org.springframework/spring-core@5.3.22?type=jar",
+        "pkg:maven/org.springframework/spring-tx@5.3.22?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/org.springframework/spring-tx@5.3.22?type=jar",
+      "dependsOn" : [
+        "pkg:maven/org.springframework/spring-beans@5.3.22?type=jar",
+        "pkg:maven/org.springframework/spring-core@5.3.22?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/jakarta.transaction/jakarta.transaction-api@1.3.3?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/jakarta.persistence/jakarta.persistence-api@2.2.3?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/org.hibernate/hibernate-core@5.6.10.Final?type=jar",
+      "dependsOn" : [
+        "pkg:maven/org.jboss.logging/jboss-logging@3.4.3.Final?type=jar",
+        "pkg:maven/net.bytebuddy/byte-buddy@1.12.13?type=jar",
+        "pkg:maven/antlr/antlr@2.7.7?type=jar",
+        "pkg:maven/org.jboss/jandex@2.4.2.Final?type=jar",
+        "pkg:maven/com.fasterxml/classmate@1.5.1?type=jar",
+        "pkg:maven/org.hibernate.common/hibernate-commons-annotations@5.1.2.Final?type=jar",
+        "pkg:maven/org.glassfish.jaxb/jaxb-runtime@2.3.6?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/org.jboss.logging/jboss-logging@3.4.3.Final?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/net.bytebuddy/byte-buddy@1.12.13?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/antlr/antlr@2.7.7?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/org.jboss/jandex@2.4.2.Final?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/com.fasterxml/classmate@1.5.1?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/org.hibernate.common/hibernate-commons-annotations@5.1.2.Final?type=jar",
+      "dependsOn" : [
+        "pkg:maven/org.jboss.logging/jboss-logging@3.4.3.Final?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/org.glassfish.jaxb/jaxb-runtime@2.3.6?type=jar",
+      "dependsOn" : [
+        "pkg:maven/jakarta.xml.bind/jakarta.xml.bind-api@2.3.3?type=jar",
+        "pkg:maven/org.glassfish.jaxb/txw2@2.3.6?type=jar",
+        "pkg:maven/com.sun.istack/istack-commons-runtime@3.0.12?type=jar",
+        "pkg:maven/com.sun.activation/jakarta.activation@1.2.2?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/jakarta.xml.bind/jakarta.xml.bind-api@2.3.3?type=jar",
+      "dependsOn" : [
+        "pkg:maven/jakarta.activation/jakarta.activation-api@1.2.2?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/jakarta.activation/jakarta.activation-api@1.2.2?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/org.glassfish.jaxb/txw2@2.3.6?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/com.sun.istack/istack-commons-runtime@3.0.12?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/com.sun.activation/jakarta.activation@1.2.2?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/org.springframework.data/spring-data-jpa@2.7.2?type=jar",
+      "dependsOn" : [
+        "pkg:maven/org.springframework.data/spring-data-commons@2.7.2?type=jar",
+        "pkg:maven/org.springframework/spring-orm@5.3.22?type=jar",
+        "pkg:maven/org.springframework/spring-context@5.3.22?type=jar",
+        "pkg:maven/org.springframework/spring-aop@5.3.22?type=jar",
+        "pkg:maven/org.springframework/spring-tx@5.3.22?type=jar",
+        "pkg:maven/org.springframework/spring-beans@5.3.22?type=jar",
+        "pkg:maven/org.springframework/spring-core@5.3.22?type=jar",
+        "pkg:maven/org.slf4j/slf4j-api@1.7.36?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/org.springframework.data/spring-data-commons@2.7.2?type=jar",
+      "dependsOn" : [
+        "pkg:maven/org.springframework/spring-core@5.3.22?type=jar",
+        "pkg:maven/org.springframework/spring-beans@5.3.22?type=jar",
+        "pkg:maven/org.slf4j/slf4j-api@1.7.36?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/org.springframework/spring-orm@5.3.22?type=jar",
+      "dependsOn" : [
+        "pkg:maven/org.springframework/spring-beans@5.3.22?type=jar",
+        "pkg:maven/org.springframework/spring-core@5.3.22?type=jar",
+        "pkg:maven/org.springframework/spring-jdbc@5.3.22?type=jar",
+        "pkg:maven/org.springframework/spring-tx@5.3.22?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/org.springframework/spring-aspects@5.3.22?type=jar",
+      "dependsOn" : [
+        "pkg:maven/org.aspectj/aspectjweaver@1.9.7?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/org.springframework.boot/spring-boot-starter-web@2.7.3?type=jar",
+      "dependsOn" : [
+        "pkg:maven/org.springframework.boot/spring-boot-starter@2.7.3?type=jar",
+        "pkg:maven/org.springframework.boot/spring-boot-starter-json@2.7.3?type=jar",
+        "pkg:maven/org.springframework.boot/spring-boot-starter-tomcat@2.7.3?type=jar",
+        "pkg:maven/org.springframework/spring-web@5.3.22?type=jar",
+        "pkg:maven/org.springframework/spring-webmvc@5.3.22?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/org.springframework.boot/spring-boot-starter-json@2.7.3?type=jar",
+      "dependsOn" : [
+        "pkg:maven/org.springframework.boot/spring-boot-starter@2.7.3?type=jar",
+        "pkg:maven/org.springframework/spring-web@5.3.22?type=jar",
+        "pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.13.3?type=jar",
+        "pkg:maven/com.fasterxml.jackson.datatype/jackson-datatype-jdk8@2.13.3?type=jar",
+        "pkg:maven/com.fasterxml.jackson.datatype/jackson-datatype-jsr310@2.13.3?type=jar",
+        "pkg:maven/com.fasterxml.jackson.module/jackson-module-parameter-names@2.13.3?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/org.springframework/spring-web@5.3.22?type=jar",
+      "dependsOn" : [
+        "pkg:maven/org.springframework/spring-beans@5.3.22?type=jar",
+        "pkg:maven/org.springframework/spring-core@5.3.22?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/com.fasterxml.jackson.datatype/jackson-datatype-jdk8@2.13.3?type=jar",
+      "dependsOn" : [
+        "pkg:maven/com.fasterxml.jackson.core/jackson-core@2.13.3?type=jar",
+        "pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.13.3?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/com.fasterxml.jackson.module/jackson-module-parameter-names@2.13.3?type=jar",
+      "dependsOn" : [
+        "pkg:maven/com.fasterxml.jackson.core/jackson-core@2.13.3?type=jar",
+        "pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.13.3?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/org.springframework.boot/spring-boot-starter-tomcat@2.7.3?type=jar",
+      "dependsOn" : [
+        "pkg:maven/jakarta.annotation/jakarta.annotation-api@1.3.5?type=jar",
+        "pkg:maven/org.apache.tomcat.embed/tomcat-embed-core@9.0.65?type=jar",
+        "pkg:maven/org.apache.tomcat.embed/tomcat-embed-el@9.0.65?type=jar",
+        "pkg:maven/org.apache.tomcat.embed/tomcat-embed-websocket@9.0.65?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/org.apache.tomcat.embed/tomcat-embed-core@9.0.65?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/org.apache.tomcat.embed/tomcat-embed-el@9.0.65?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/org.apache.tomcat.embed/tomcat-embed-websocket@9.0.65?type=jar",
+      "dependsOn" : [
+        "pkg:maven/org.apache.tomcat.embed/tomcat-embed-core@9.0.65?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/org.springframework/spring-webmvc@5.3.22?type=jar",
+      "dependsOn" : [
+        "pkg:maven/org.springframework/spring-aop@5.3.22?type=jar",
+        "pkg:maven/org.springframework/spring-beans@5.3.22?type=jar",
+        "pkg:maven/org.springframework/spring-context@5.3.22?type=jar",
+        "pkg:maven/org.springframework/spring-core@5.3.22?type=jar",
+        "pkg:maven/org.springframework/spring-expression@5.3.22?type=jar",
+        "pkg:maven/org.springframework/spring-web@5.3.22?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/org.springframework.boot/spring-boot-starter-validation@2.7.3?type=jar",
+      "dependsOn" : [
+        "pkg:maven/org.springframework.boot/spring-boot-starter@2.7.3?type=jar",
+        "pkg:maven/org.apache.tomcat.embed/tomcat-embed-el@9.0.65?type=jar",
+        "pkg:maven/org.hibernate.validator/hibernate-validator@6.2.4.Final?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/org.hibernate.validator/hibernate-validator@6.2.4.Final?type=jar",
+      "dependsOn" : [
+        "pkg:maven/jakarta.validation/jakarta.validation-api@2.0.2?type=jar",
+        "pkg:maven/org.jboss.logging/jboss-logging@3.4.3.Final?type=jar",
+        "pkg:maven/com.fasterxml/classmate@1.5.1?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/jakarta.validation/jakarta.validation-api@2.0.2?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/org.springframework.boot/spring-boot-starter-thymeleaf@2.7.3?type=jar",
+      "dependsOn" : [
+        "pkg:maven/org.springframework.boot/spring-boot-starter@2.7.3?type=jar",
+        "pkg:maven/org.thymeleaf/thymeleaf-spring5@3.0.15.RELEASE?type=jar",
+        "pkg:maven/org.thymeleaf.extras/thymeleaf-extras-java8time@3.0.4.RELEASE?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/org.thymeleaf/thymeleaf-spring5@3.0.15.RELEASE?type=jar",
+      "dependsOn" : [
+        "pkg:maven/org.thymeleaf/thymeleaf@3.0.15.RELEASE?type=jar",
+        "pkg:maven/org.slf4j/slf4j-api@1.7.36?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/org.thymeleaf/thymeleaf@3.0.15.RELEASE?type=jar",
+      "dependsOn" : [
+        "pkg:maven/org.attoparser/attoparser@2.0.5.RELEASE?type=jar",
+        "pkg:maven/org.unbescape/unbescape@1.1.6.RELEASE?type=jar",
+        "pkg:maven/org.slf4j/slf4j-api@1.7.36?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/org.attoparser/attoparser@2.0.5.RELEASE?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/org.unbescape/unbescape@1.1.6.RELEASE?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/org.thymeleaf.extras/thymeleaf-extras-java8time@3.0.4.RELEASE?type=jar",
+      "dependsOn" : [
+        "pkg:maven/org.thymeleaf/thymeleaf@3.0.15.RELEASE?type=jar",
+        "pkg:maven/org.slf4j/slf4j-api@1.7.36?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/com.h2database/h2@2.1.214?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/mysql/mysql-connector-java@8.0.30?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/org.postgresql/postgresql@42.3.6?type=jar",
+      "dependsOn" : [
+        "pkg:maven/org.checkerframework/checker-qual@3.5.0?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/org.checkerframework/checker-qual@3.5.0?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/javax.cache/cache-api@1.1.1?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/org.ehcache/ehcache@3.10.0?type=jar",
+      "dependsOn" : [
+        "pkg:maven/javax.cache/cache-api@1.1.1?type=jar",
+        "pkg:maven/org.slf4j/slf4j-api@1.7.36?type=jar",
+        "pkg:maven/org.glassfish.jaxb/jaxb-runtime@2.3.6?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/org.webjars.npm/bootstrap@5.1.3?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/org.webjars.npm/font-awesome@4.7.0?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/org.springframework.boot/spring-boot-devtools@2.7.3?type=jar",
+      "dependsOn" : [
+        "pkg:maven/org.springframework.boot/spring-boot@2.7.3?type=jar",
+        "pkg:maven/org.springframework.boot/spring-boot-autoconfigure@2.7.3?type=jar"
+      ]
+    }
+  ]
+},
+  "git-metadata": {
+"repository-url": "https://github.com/Eknathreddy09/spring-petclinic-appadvisor",
+  "commit": {
+    "sha": "1f5f924a461451c5043b1918ab14336caa2cd30c",
+	"refs": [ "HEAD","refs/heads/main","refs/remotes/origin/HEAD","refs/remotes/origin/main" ],
+	"time": 1749744365000
+  }
+},
+
+  "tools": [
+    { "name": "mvnw", "version": "3.8.1" },
+    { "name": "java", "version": "8"}
+  ],
+  "submodules": ["org.springframework.samples:spring-petclinic"]
+}


### PR DESCRIPTION
Applied by Spring Application Advisor v1.3.1

Changes:
- Updated Java version from 8 to 11
- Updated Maven/Gradle configuration
- Applied necessary code transformations

Auto-generated commit by GitHub Actions